### PR TITLE
Add theme fonts and colors

### DIFF
--- a/site/content/components/Hero.jsx
+++ b/site/content/components/Hero.jsx
@@ -1,19 +1,19 @@
 export default function Hero() {
   return (
-    <main className="lg:relative">
-      <div className="mx-auto w-full max-w-7xl pt-16 pb-20 text-center lg:pt-48 lg:pb-32 lg:text-left">
+    <section className="lg:relative">
+      <div className="font-archivo mx-auto w-full max-w-7xl pt-16 pb-20 text-center lg:pt-48 lg:pb-32 lg:text-left">
         <div className="px-4 sm:px-8 lg:w-1/2 xl:pr-16">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl flex flex-col">
             <span className="block xl:inline">We are</span>
-            <span className="block text-[#F0CA5E] xl:inline">pragmatic utopians.</span>
+            <span className="block text-theme-yellow xl:inline">pragmatic utopians.</span>
           </h1>
           <p className="mx-auto mt-3 max-w-md text-lg text-gray-500 sm:text-xl md:mt-5 md:max-w-3xl">We’re committed to practical action for a radically wiser, weller world. We create hubs, do research and engage in advocacy to pioneer a wiser culture.</p>
           <div className="mt-10 sm:flex sm:justify-center lg:justify-start">
             <div className="rounded-md shadow">
-              <a href="#hubs" className="flex w-full items-center justify-center rounded-md border border-transparent bg-[#F0CA5E] px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">LEARN MORE</a>
+              <a href="#hubs" className="flex w-full items-center justify-center rounded-md border border-transparent bg-theme-yellow px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">LEARN MORE</a>
             </div>
             <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
-              <a href="#" className="flex w-full items-center justify-center rounded-md border border-transparent bg-[#F0CA5E] px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">JOIN A MONTH RESIDENCY</a>
+              <a href="#" className="flex w-full items-center justify-center rounded-md border border-transparent bg-theme-yellow px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">JOIN A MONTH RESIDENCY</a>
             </div>
           </div>
         </div>
@@ -21,6 +21,6 @@ export default function Hero() {
       <div className="relative h-64 w-full sm:h-72 md:h-96 lg:absolute lg:inset-y-0 lg:right-0 lg:h-full lg:w-1/2">
         <img className="absolute inset-0 mx-auto h-full object-fit" src="assets/lifeitself-landingpage.webp" alt="" />
       </div>
-    </main>
+    </section>
   )
 }

--- a/site/content/components/Team.jsx
+++ b/site/content/components/Team.jsx
@@ -193,7 +193,7 @@ function List({ data }) {
   return (
     <ul
       role="list"
-      className="space-y-12 lg:grid lg:grid-cols-3 lg:items-start lg:gap-x-8 lg:gap-y-12 lg:space-y-0"
+      className="font-archivo space-y-12 lg:grid lg:grid-cols-3 lg:items-start lg:gap-x-8 lg:gap-y-12 lg:space-y-0"
     >
       {data.map((person) => (
         <li key={person.name}>

--- a/site/layouts/docs.jsx
+++ b/site/layouts/docs.jsx
@@ -2,7 +2,7 @@
 export default function DocsLayout({ children, frontMatter }) {
   const { title } = frontMatter;
   return (
-    <article className="docs prose dark:prose-invert prose-a:break-words mx-auto p-6">
+    <article className="docs prose font-archivo dark:prose-invert prose-a:break-words mx-auto p-6">
       <header>
         <div className="mb-6">{title && <h1>{title}</h1>}</div>
       </header>

--- a/site/styles/global.css
+++ b/site/styles/global.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100;0,300;0,400;0,700;0,800;1,100;1,300;1,400;1,500;1,700&display=swap');
+
 /* mathjax */
 .math-inline {
   display: flex;

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -1,3 +1,5 @@
+const colors = require("tailwindcss/colors")
+
 module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
@@ -11,6 +13,12 @@ module.exports = {
       // support wider width for large screens >1440px eg. in hero
       maxWidth: {
         "8xl": "88rem",
+      },
+      fontFamily: {
+        archivo: ['Archivo']
+      },
+      colors: {
+        "theme-yellow": "#F0CA5E"
       },
     },
   },


### PR DESCRIPTION
### Summary

This PR adds a custom font and theme color for tailwind classes

### Changes

* Import fonts in `styles/global.css` - using https://fonts.google.com/specimen/Archivo?query=archivo
* Add the fonts and colors to tailwind classes
* Use fonts/colors in docs layout for pages, and in team and Hero components

### Screenshot
<img width="1439" alt="Screen Shot 2022-11-10 at 2 47 39 PM" src="https://user-images.githubusercontent.com/42637597/201071527-e653eb02-dd84-43f2-83a7-711a2a65c7cf.png">
