### PR TITLE
Adding five mindfulness trainings link to practices

### DIFF
--- a/vault/tao/practices.md
+++ b/vault/tao/practices.md
@@ -1,7 +1,7 @@
 # Practices
 
 * [Five Remebrances](/five-remembrances/)
-* [Five Mindfulness Trainings](/notes/five-mindfulness-trainings/)
+* [Five Mindfulness Trainings](/five-mindfulness-trainings/)
 * [[../notes/shining-light|Shining a Light]]
 
 ## Contemplations Before Eating

--- a/vault/tao/practices.md
+++ b/vault/tao/practices.md
@@ -1,7 +1,7 @@
 # Practices
 
 * [Five Remebrances](/five-remembrances/)
-* [Five Mindfulness Trainings](/five-mindfulness-trainings/)
+* [Five Mindfulness Trainings](/notes/five-mindfulness-trainings/)
 * [[../notes/shining-light|Shining a Light]]
 
 ## Contemplations Before Eating

--- a/vault/tao/practices.md
+++ b/vault/tao/practices.md
@@ -1,7 +1,7 @@
 # Practices
 
 * [Five Remebrances](/five-remembrances/)
-* [Five Mindfulness Trainings](/five-mindfulness-trainings/)
+* [[five-mindfulness-trainings|Five Mindfulness Trainings]] 
 * [[../notes/shining-light|Shining a Light]]
 
 ## Contemplations Before Eating


### PR DESCRIPTION
I accidentally added the note five mindfulness trainings to notes already and this is just updating the link on the tao/practices to the correct place