### PR TITLE
[vault,pages][m]: replace pages with fixed image paths + add missing images

### DIFF
--- a/vault/2-week-relational-embodiment-residency.md
+++ b/vault/2-week-relational-embodiment-residency.md
@@ -13,7 +13,7 @@ authors:
 
 **Bergerac, France**
 
-![](assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
+![](/assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
 
 [**Apply Now**](https://docs.google.com/forms/d/e/1FAIpQLSdwDceOgSSk3IlkR5AG8DNpnDATuWILTvpzJxeRjZh7KZ4h1w/viewform?usp=sf_link)
 
@@ -102,7 +102,7 @@ We will have a maximum of 18 participants and 6 facilitators and participants wi
 
 [Life Itself Praxis Hub, Bergerac](https://lifeitself.org/hubs/bergerac/), France. A palazzo in the Dordogne in the medieval town of Bergerac near Bordeaux.
 
-![View of Bergerac on the Dordogne](assets/images/ima5206798460595800666-e1653592511495.jpeg)
+![View of Bergerac on the Dordogne](/assets/images/ima5206798460595800666-e1653592511495.jpeg)
 
 ### How does it cost?
 
@@ -124,25 +124,25 @@ Residency Application Procedure:
 
 **[Apply Now via the Online Form](https://docs.google.com/forms/d/e/1FAIpQLSdwDceOgSSk3IlkR5AG8DNpnDATuWILTvpzJxeRjZh7KZ4h1w/viewform?usp=sf_link)**
 
-![a man and a woman serve food onto plates](assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
+![a man and a woman serve food onto plates](/assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
 
 * * *
 
 ## Facilitation & Hosting Team
 
-![](assets/images/TEAM3-1-1024x1024.jpg)
+![](/assets/images/TEAM3-1-1024x1024.jpg)
 
 **Boaz** is a clinical psychologist, a Dharma teacher in the Western Insight tradition and a trainer acting for worldwide positive change. He has worked with international organisations (UNHCR, UNOCHA, WHO, Doctors Without Borders) in a variety of humanitarian contexts, studied MBCT/MBSR at [University of Oxford](https://www.oxfordmindfulness.org/)/[Bangor](https://www.bangor.ac.uk/mindfulness/), and ordained as a Buddhist Monk in Thailand in his early 20's. He founded NeuroSystemics, an integrative somatically-centred approach for spiritual, and psychosocial development and healing.
 
-![](assets/images/Rebekka_Simple-1024x1024.jpg)
+![](/assets/images/Rebekka_Simple-1024x1024.jpg)
 
 ****Rebekka**** is a mindfulness coach (ICF) and counsellor for individual and group sessions. She is extensively trained in Organic Intelligence®, a clinical protocol for trauma resolution through shepherding nervous system states from bottom-up. Her participation in NeuroSystemics expands her contribution to healing from an individual to a greater, psycho-social frame through group work. She is a certified yoga teacher and the co-founder of multiple yoga Studios.
 
-![](assets/images/Heath_Simple-1024x1024.jpg)
+![](/assets/images/Heath_Simple-1024x1024.jpg)
 
 Working over 30 years, **Heath** weaves his expertise as a psychologist, trauma healer, rolf practitioner, craniosacral therapist, enneagram consultant, dating/relationship coach, and has been trained  in Somatic Experiencing. Heath has a long-standing Vipassana meditation practice and founded the 5aspects® center, where Body, Sexuality, Heart, Mind and Spirit can heal, grow and flourish.
 
-![](assets/images/TEAM6-copy-1024x1024.jpg)
+![](/assets/images/TEAM6-copy-1024x1024.jpg)
 
 **Helena** is an Entrepreneur, Researcher and Human Empowerment and Resiliency Coach (Organic Intelligence) and an International Voice & Acting Coach. She is the CEO and Founder of Helena Walsh Empowerment Studios.  Over the past twenty five years she has worked with people all over the world, from top executives and CEO's, to preparing leading actors for major TV network shows.
 
@@ -150,6 +150,6 @@ Working over 30 years, **Heath** weaves his expertise as a psychologist, traum
 
 * * *
 
-![](assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
+![](/assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
 
 * * *

--- a/vault/assets/images/15030017-scaled.jpg
+++ b/vault/assets/images/15030017-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47348be284fb8a9182beb00c5a1511ad4c82de4c2b1e213787f3d1b4b729c236
+size 754033

--- a/vault/assets/images/1909newsletter-gathering-meal-2019-1024x576-1.jpg
+++ b/vault/assets/images/1909newsletter-gathering-meal-2019-1024x576-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ba93b682a983269831b013e5c4e44612c4ada3ee82c3f147cf06aeb732157cd
+size 154019

--- a/vault/assets/images/20200717_072527.jpg
+++ b/vault/assets/images/20200717_072527.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fef30df718284043732fcab2e2859f2ae5cf5112b1f2a9ce5c23223e7ce3caba
+size 902462

--- a/vault/assets/images/Blog-Feature-Images-11.png
+++ b/vault/assets/images/Blog-Feature-Images-11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e318e96cd56c591dda859d3c191a9e068958693e4f3a502ad5990ff88a2d09dd
+size 4464602

--- a/vault/assets/images/Blog-Feature-Images-29.jpg
+++ b/vault/assets/images/Blog-Feature-Images-29.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:953733fcb208f58f888c59477cd840aa1f0a78a10d4744f107163c0da2fe3cc0
+size 300105

--- a/vault/assets/images/Page-Feature-Images.jpg
+++ b/vault/assets/images/Page-Feature-Images.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5579fc9633b1a595ee6b4f7671df775965f16da881e7c627350c1251baa34179
+size 268272

--- a/vault/assets/images/Social_Change_Ecosystem.png
+++ b/vault/assets/images/Social_Change_Ecosystem.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50c99d5fd987cb01f0de3ba66ead8d22c58820224a8226b34c37ca44da8b4c5e
+size 925026

--- a/vault/assets/images/a_state_1.jpg
+++ b/vault/assets/images/a_state_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba3603545eca5d4f6f2171bd6db5eb34922f76df5bfb69d139745c8575592aea
+size 596455

--- a/vault/assets/images/bergerac-photo-1.jpg
+++ b/vault/assets/images/bergerac-photo-1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79ebc65b854ea5536a18eeb13fa4be1dbb1660bc86a86e90cd9e308018a41d4f
+size 280388

--- a/vault/assets/images/berlin-hub-2.jpg
+++ b/vault/assets/images/berlin-hub-2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47787af510b24077366e966c80ef3e74c2b884cff7e5f127b9f03d538b1ead8f
+size 248824

--- a/vault/assets/images/calls1.jpg
+++ b/vault/assets/images/calls1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58d7a1b670320574dd09f8179e0dfd2de3fd7ed3662126d49286408ed7c872fc
+size 78754

--- a/vault/assets/images/calls3-scaled.jpg
+++ b/vault/assets/images/calls3-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d584ceee231cbe353b8c5bd1c8540b7db02ed4e8d102b03960f506bf6a964e
+size 755608

--- a/vault/assets/images/carcrash-scaled.jpg
+++ b/vault/assets/images/carcrash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab55ac5a07ffb21bc7435540c1dfec633eba07e5efbac5e2b01713efd580a99b
+size 382696

--- a/vault/assets/images/cecile01.jpg
+++ b/vault/assets/images/cecile01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a87f15998d328d78af8b7a260ee105898259fdb235ff01859ec9bdc8d526cafe
+size 223636

--- a/vault/assets/images/davide-ragusa-24118-unsplash-scaled.jpg
+++ b/vault/assets/images/davide-ragusa-24118-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ef06cf9ca9364f554fd180bfbae93acd1002af9d6e38e9155960aec040a5872
+size 733968

--- a/vault/assets/images/dsc_9969_sarah_hickson.jpg
+++ b/vault/assets/images/dsc_9969_sarah_hickson.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7e641cbb82f1f210f53014ed23d8342a897e2efda58dda1181f1615ef321cd
+size 651045

--- a/vault/assets/images/ethan-hoover-325423-unsplash-scaled.jpg
+++ b/vault/assets/images/ethan-hoover-325423-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eeae542cfc1978979340098d3f5f306a31b8cd1f49a3eeacec60e28f3e5064c
+size 611007

--- a/vault/assets/images/fire_camping_campfire_group_sitting-80446.jpg
+++ b/vault/assets/images/fire_camping_campfire_group_sitting-80446.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb59b6246ac7f8fa69645c4f5be608c3ab1fef4c234987f1d084fa101cdfb4c8
+size 102931

--- a/vault/assets/images/haseeb-jamil-zbg2-gyo_hM-unsplash-scaled.jpg
+++ b/vault/assets/images/haseeb-jamil-zbg2-gyo_hM-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1282310a93488b654f074cdb48827f9dcaabfbd1ae57866c072a3e5d1a9aff5
+size 789936

--- a/vault/assets/images/hubs.jpg
+++ b/vault/assets/images/hubs.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3ef953f8633ba225076a7fb2a2c29761a479a06c83477e80fa93aeaef860c8
+size 239625

--- a/vault/assets/images/ills-of-cap.jpg
+++ b/vault/assets/images/ills-of-cap.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b8b7f9bbb14961bce220507efb8d0e6987f84ca658c67b0725f7779fe92ad7e
+size 801789

--- a/vault/assets/images/institute_cover_resized.jpg
+++ b/vault/assets/images/institute_cover_resized.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fed2483656db9316955868d3be3311351bf618fca0aaa9d0ccae78e4c31297a
+size 193685

--- a/vault/assets/images/institute_stef_ruf_resized.jpg
+++ b/vault/assets/images/institute_stef_ruf_resized.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e90d24bfb2bdb707cb40148cdb5988925d38794658eb6c6216e8a6a927c358da
+size 488739

--- a/vault/assets/images/mike-erskine-S_VbdMTsdiA-unsplash-scaled.jpg
+++ b/vault/assets/images/mike-erskine-S_VbdMTsdiA-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86be50013866edaf73d31597f281633e363207ad7e73cb6111d0a2c0ecee0841
+size 232861

--- a/vault/assets/images/ruben-ortega-viel7n9kgNA-unsplash-scaled.jpg
+++ b/vault/assets/images/ruben-ortega-viel7n9kgNA-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a188dcc360971af1bed1f15289ad230315ff92dec8c31e6ad43792a850ee210
+size 806051

--- a/vault/assets/images/shubham-dhage-gC_aoAjQl2Q-unsplash-scaled.jpg
+++ b/vault/assets/images/shubham-dhage-gC_aoAjQl2Q-unsplash-scaled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3380bf3b092b045137041535f310984f5d2823edb8e9a9ce4e6974691220914
+size 148023

--- a/vault/back-to-basics.md
+++ b/vault/back-to-basics.md
@@ -7,7 +7,7 @@ authors:
 
 ESSENTIAL FOOD
 
-![](assets/images/57ad5de930708c0650d38a1fc4dadb1b05647fec129a7233f87f6034b24de9e5-2-675x1024.jpg)
+![](/assets/images/57ad5de930708c0650d38a1fc4dadb1b05647fec129a7233f87f6034b24de9e5-2-675x1024.jpg)
 
 crédit photo Eléonore Grignon
 
@@ -178,7 +178,7 @@ Plus d'informations sur les résidences Sympoiesis
 
  [https://lifeitself.org/sympoiesis/](https://lifeitself.org/sympoiesis/)
 
-![](assets/images/image-1.png)
+![](/assets/images/image-1.png)
 
 Credit photo Eléonore Grignon
 
@@ -202,7 +202,7 @@ Credit photo Eléonore Grignon
 
 ### Valérie Duvauchelle
 
-![](assets/images/Eleonore-grignon-pour-ilots-magazine-4-679x1024.jpg)
+![](/assets/images/Eleonore-grignon-pour-ilots-magazine-4-679x1024.jpg)
 
 ( photo Eleonore Grigon pour Ilots Magazine)
 
@@ -213,7 +213,7 @@ Son site : [](https://en.lacuisinedelabienveillance.org/les-messagers)[la cuisin
 
 ### Ôna Maiocco
 
-![](assets/images/cueillette_grenouille_4_recadree-944x1024.jpeg)
+![](/assets/images/cueillette_grenouille_4_recadree-944x1024.jpeg)
 
 Ôna Maiocco a été l'une des pionnières de la cuisine vegan en France. Après avoir crée l'atelier super naturelle à Paris afin de promouvoir une cuisine de résilience , locale et écologique elle est désormais installée dans la Creuse ou elle cultive son jardin et explore l'abondance de la nature au quotidien .
 

--- a/vault/blind-spots.md
+++ b/vault/blind-spots.md
@@ -3,6 +3,7 @@ title: "Blind Spots"
 created: 2020-10-07
 authors: 
   - artearthtech
+image: /assets/images/carcrash-scaled.jpg
 ---
 
 ## About Blind Spots
@@ -17,7 +18,7 @@ Literally a blind spot is a part of our visual field we can’t see – and whic
 
 More generally, imagine you are in your car parking at the supermarket, you look around, check, then back up and CRASH! You’ve driven into a pole. When you get home, your partner says “Didn’t you look and check your mirrors?!” You say “Of course I did! But it was in my blind spot!”
 
-![](assets/images/carcrash.jpg)
+![](/assets/images/carcrash.jpg)
 
 Our blind spots are not only what we can’t see but what we can’t see that we can’t see. What we don’t know and that we don’t know that we don’t know.
 
@@ -35,7 +36,7 @@ There is a longing for community and belongingness yet there is a huge fear of c
 
 Why is it we can’t talk about politics and religion in a civilised way?
 
-![](assets/images/pub.jpg)
+![](/assets/images/pub.jpg)
 
 ## Blind Spot Examples
 

--- a/vault/calls.md
+++ b/vault/calls.md
@@ -3,6 +3,7 @@ title: "Calls"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/institute_cover_resized.jpg
 ---
 
 ## We're limitless. So are you.
@@ -17,7 +18,7 @@ People like people like them. Our calls are full of people seeking wise alternat
 
 Our calls are facilitated by Life Itself coaches, each of whom has extensive experience running online calls and workshops, in addition to living an intentional life. You’re in good hands. 
 
-![](assets/images/calls1-1.jpg)
+![](/assets/images/calls1-1.jpg)
 
 #### The Art of Autobiography
 
@@ -25,7 +26,7 @@ Discover yourself through narrative. Author your past, free your future. 
 
 [more info](/calls/autobiography/)
 
-![](assets/images/calls2-1024x684.jpg)
+![](/assets/images/calls2-1024x684.jpg)
 
 #### Sunday Salons
 
@@ -33,7 +34,7 @@ Discuss the issues that matter. Expert led, community driven.
 
 [more info](/calls/sunday-salon/)
 
-![](assets/images/calls3-1024x663.jpg)
+![](/assets/images/calls3-1024x663.jpg)
 
 #### Get Stuff Done!
 

--- a/vault/calls/autobiography.md
+++ b/vault/calls/autobiography.md
@@ -3,6 +3,7 @@ title: "Autobiography"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/calls1.jpg
 ---
 
 ## Write!

--- a/vault/calls/get-it-done.md
+++ b/vault/calls/get-it-done.md
@@ -3,6 +3,7 @@ title: "Get It-done"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/calls3-scaled.jpg
 ---
 
 ## Build Your Discipline

--- a/vault/calls/sunday-salon.md
+++ b/vault/calls/sunday-salon.md
@@ -3,6 +3,7 @@ title: "Sunday Salon"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/cecile01.jpg
 ---
 
 ## Learn from experts

--- a/vault/collaborators.md
+++ b/vault/collaborators.md
@@ -3,9 +3,10 @@ title: "Collaborators"
 created: 2020-03-18
 authors: 
   - sylvieshiweibarbier
+image: /assets/images/dsc_9969_sarah_hickson.jpg
 ---
 
-![](assets/images/Plum-village-logo.png)
+![](/assets/images/Plum-village-logo.png)
 
 #### Plum Village
 
@@ -15,7 +16,7 @@ Plum Village, near Bordeaux in southwest France, is a world renowned practice ce
 
 Plum Village is where Thich Nhat Hanh has realised his dream of building a Beloved Community: creating a healthy, nourishing environment where people can learn the art of living in harmony with one another and with the Earth.
 
-![](assets/images/untitled_logo.svg)
+![](/assets/images/untitled_logo.svg)
 
 #### Untitled
 
@@ -23,7 +24,7 @@ Life Itself is proud to call Untitled one of our closest collaborators. We have 
 
 UNTITLED’s purpose is to collectively reimagine the society, set the agenda for the most important experiments and execute them together. It is founded by an alliance of activists across sectors. The Alliance and its invitees gather together in an annual festival.
 
-![](assets/images/1200px-LSE_Logo.svg_-300x300.png)
+![](/assets/images/1200px-LSE_Logo.svg_-300x300.png)
 
 #### LSE
 
@@ -33,7 +34,7 @@ London School of Economics is unique in its concentration on teaching and resear
 
 [https://www.lse.ac.uk/](https://www.lse.ac.uk/)
 
-![](assets/images/Rockefeller-Foundation-300x79.png)
+![](/assets/images/Rockefeller-Foundation-300x79.png)
 
 #### Rockefeller Foundation
 
@@ -43,7 +44,7 @@ You can find more about the project here: [http://imedproject.org/](http://imed
 
 The Rockefeller Foundation’s mission—unchanged since 1913—is to promote the well-being of humanity throughout the world. Today the Foundation advances new frontiers of science, data, policy, and innovation to solve global challenges related to health, food, power, and economic mobility.
 
-![](assets/images/IPPR-2017-Logo_Standard_pink-248x300.png)
+![](/assets/images/IPPR-2017-Logo_Standard_pink-248x300.png)
 
 #### IPPR
 
@@ -51,7 +52,7 @@ For our Blind Spot Event with Roberto Unger we were delighted to collaborate wit
 
 [http://www.ippr.org/](http://www.ippr.org/)
 
-![](assets/images/Open_Knowledge_International_Logo-291x300.png)
+![](/assets/images/Open_Knowledge_International_Logo-291x300.png)
 
 #### Open Knowledge
 
@@ -69,11 +70,11 @@ Open Knowledge International is a worldwide network of people passionate about o
 
 [https://okfn.org/](https://okfn.org/)
 
-![](assets/images/1200px-CRI-logo-sq.svg_-1-300x300.png)
+![](/assets/images/1200px-CRI-logo-sq.svg_-1-300x300.png)
 
 #### CRI
 
-We collaborated with the leading Institute for Interdisciplinary research in France, CRI in organising a dialogue on the Open Science of Learning. You can read the white paper which arose out of this exchange here: [https://artearthtech.files.wordpress.com/2020/06/the-world-needs-a-truly-open-science-of-learning.pdf](assets/the-world-needs-a-truly-open-science-of-learning.pdf)
+We collaborated with the leading Institute for Interdisciplinary research in France, CRI in organising a dialogue on the Open Science of Learning. You can read the white paper which arose out of this exchange here: [https://artearthtech.files.wordpress.com/2020/06/the-world-needs-a-truly-open-science-of-learning.pdf](/assets/the-world-needs-a-truly-open-science-of-learning.pdf)
 
 CRI was founded by François Taddei and Ariel Lindner in 2005 to create a student/researcher centered open environment in which they can collaborate together to build a world where lifelong learning is at the heart of our society.
 
@@ -83,7 +84,7 @@ Sitting at the crossroads of research and education, CRI advocates for innovativ
 
 [https://cri-paris.org/](https://cri-paris.org/)
 
-![](assets/images/datopian.png)
+![](/assets/images/datopian.png)
 
 #### Datopian
 
@@ -93,7 +94,7 @@ We build tools, provide advice, implement projects, and develop communities in t
 
 [www.datopian.com](https://www.datopian.com)
 
-![](assets/images/imed-logo04-1-300x164.png)
+![](/assets/images/imed-logo04-1-300x164.png)
 
 #### iMed
 
@@ -103,7 +104,7 @@ The best resolution to the tension between access and innovation is a remunerati
 
 Read more on: [http://imedproject.org/](http://imedproject.org/)
 
-![](assets/images/leap-logo.png)
+![](/assets/images/leap-logo.png)
 
 #### The LEAP Education
 
@@ -115,7 +116,7 @@ Life Itself provided key initial inspiration, consulting and incubation for The 
 
 [https://www.theleap-tw.com/](https://www.theleap-tw.com/)
 
-![](assets/images/ecosoulhostel-1.png)
+![](/assets/images/ecosoulhostel-1.png)
 
 #### Eco soul hostel
 
@@ -129,7 +130,7 @@ We invite guests to enjoy a sense of shared responsibility for the living space.
 
 [https://www.ecosoulhostel.com/](https://www.ecosoulhostel.com/)
 
-![](assets/images/coco-1.png)
+![](/assets/images/coco-1.png)
 
 #### Conscious
 
@@ -143,7 +144,7 @@ Coco consults with shared living ventures to transform their communities so that
 
 [https://www.consciouscoliving.com](https://www.consciouscoliving.com)
 
-![](assets/images/lifecloud.png)
+![](/assets/images/lifecloud.png)
 
 #### Life Cloud
 
@@ -155,7 +156,7 @@ Life Cloud is dedicated to create the mental, physical, emotional and social are
 
 [https://www.lifecloudmap.com/](https://www.lifecloudmap.com/)
 
-![](assets/images/spendwithlove-300x293.png)
+![](/assets/images/spendwithlove-300x293.png)
 
 #### Spend with love
 
@@ -163,7 +164,7 @@ How we spend our money shapes the world Sparking a global conversation with wor
 
 [http://www.spendwithlove.org/](http://www.spendwithlove.org/)
 
-![](assets/images/logo_purple-e1475606726432.png)
+![](/assets/images/logo_purple-e1475606726432.png)
 
 #### WooWoo
 

--- a/vault/collective-wisdom.md
+++ b/vault/collective-wisdom.md
@@ -3,6 +3,7 @@ title: "Collective Wisdom"
 created: 2020-08-14
 authors: 
   - liamaet
+image: /assets/images/davide-ragusa-24118-unsplash-scaled.jpg
 ---
 
 Western society is deeply attached to ”Enlightenment” ideals of rationality, individualism and equality. These have become dogma, taboo to even question, which creates blindspots central to unfolding ecological and political crises. Looking into these blindspots is way of rediscovering the capacity for deep intuition, collective action, and politics motivated by love.

--- a/vault/conscious-food-workshop.md
+++ b/vault/conscious-food-workshop.md
@@ -60,7 +60,7 @@ Sans ordre particulier, au cours de cette résidence nous allons expérimenter c
 - Analyser notre relation intime à la nourriture
 - Explorer la notion de besoin
 
-![](assets/images/IMG_1534-1024x1024.jpeg)
+![](/assets/images/IMG_1534-1024x1024.jpeg)
 
 #### 2 axis :
 
@@ -81,7 +81,7 @@ The art of recycling
 The movement of the bowls  
 The dynamic absorption of sitting, cooking , eating
 
-![](assets/images/P5080066.jpg)
+![](/assets/images/P5080066.jpg)
 
 #### L'enseignement se compose de deux volets :
 
@@ -102,7 +102,7 @@ The dynamic absorption of sitting, cooking , eating
 - Le mouvement des bols
 - L'absorption dynamique de s'assoir, cuisiner, manger
 
-![](assets/images/P5080066.jpg)
+![](/assets/images/P5080066.jpg)
 
 ## Community of practices
 
@@ -139,7 +139,7 @@ Pour plus d'informations sur les PMV lire le document en lien . 
 
 Ce stage vise à aider les cuisiniers à pratiquer la nourriture comme un espace dynamique à vivre . L'atelier a été développé grâce à l'expérience de Valérie qui a étudié avec des enseignants et des cuisiniers zen (Tenzo) et cuisine dans des communautés et pour des retraites. Cette pratique de la nourriture est une proposition laïque de la cuisine Shojin des temples zen, adaptée à notre terroir.
 
-![](assets/images/191111-cuisine-zen2-1-1024x680.jpg)
+![](/assets/images/191111-cuisine-zen2-1-1024x680.jpg)
 
 Crédit photo Anne Gabrielle Dumont
 
@@ -187,7 +187,7 @@ More about our residencies
 
  [https://lifeitself.org/sympoiesis/](https://lifeitself.org/sympoiesis/)
 
-![](assets/images/class-people-1024x819.jpg)
+![](/assets/images/class-people-1024x819.jpg)
 
 ### Testimonials
 
@@ -208,7 +208,7 @@ More about our residencies
 > 
 > Catherine Sengthavy , kinésithérapeute, praticienne shiatsu et tenzo
 
-![](assets/images/IMG-20210803-WA0028-1024x768.jpg)
+![](/assets/images/IMG-20210803-WA0028-1024x768.jpg)
 
 > My encounter with Valérie has profoundly transformed my relationship with cooking. As a fan of "flashy" seasonings, I was able to discover another way of cooking that gives pride of place to the meeting of the moment with the ingredient, allowing listening before any "voluntarist" intervention, erasing the ego and inviting us to a new dance. My seasonings are now much simpler and even more delicious! This simple but crucial aspect of my cooking has evolved enormously thanks to Valerie: cooking with her and receiving her teaching has allowed me to become aware of my position as a creative cook and teacher. The common thread of her practice, around the activation of the "living" through the act of cooking and eating, has brought to light feelings that I had not been able to connect to anything before. Thanks to her, I now welcome my life as a cook with much more peace and satisfaction. The five contemplations of shojin ryori resonate with me every day, while Valerie's reflections on "goodness" in the kitchen feed my need for simplicity, commitment, resilience and generosity in the kitchen. It's a priceless gift in these troubled times to put cooking back at the heart of our lives and communities, the indispensable engine of our joyful sustenance…and I am so grateful.
 > 
@@ -218,7 +218,7 @@ More about our residencies
 > 
 > Ona Maioco, vegan chef, at [super-naturelle](http://www.super-naturelle.com)
 
-![](assets/images/th.jpeg)
+![](/assets/images/th.jpeg)
 
 > One of the first things that touched me was the fluidity and simplicity with which everything was organized in the kitchen, in a true collaboration. Valerie was able to quickly establish a trust and sharing that was precious to me, not posing as the sole holder of the knowledge, but asking us for our point of view on this or that ingredient to be added, and calling upon our own creativity. She managed to give us a subtle mix of joy and attention that allowed me to learn a lot about food preparation of course, but also about managing a group in the kitchen, in a relatively short time. When I returned, my close family, friends and people who come on retreat to our place of healing, were able to enjoy it fully. The quality of the presentation, the variety of the proposals, the fact that I dared to be even more creative with what I had and the joy that this gave me, were immediately felt by my daily guests. I feel a deep gratitude for what Valerie has given me, and there is something life changing about this teaching. Thank you for this!
 
@@ -226,7 +226,7 @@ More about our residencies
 > 
 > Sandra dao , retreat Participant, facilitator and owner of [La Source](https://espacedelasource.com) , a retreats place
 
-![](assets/images/th-1-1.jpeg)
+![](/assets/images/th-1-1.jpeg)
 
 > This experience has led me to reflect on: the seeming benefits/importance of (measured) hunger; the importance of variety; the importance of raw foods and balanced flavours. What has been most striking has not just been the physical benefits from this, but the meditative / calming aspects too. It is very rare that a lunch/dinner will inspire this level of reflection in me, and so that in itself speaks volumes!
 > 
@@ -244,7 +244,7 @@ More about our residencies
 
 ### Valérie Duvauchelle
 
-![](assets/images/Eleonore-grignon-pour-ilots-magazine-4-679x1024.jpg)
+![](/assets/images/Eleonore-grignon-pour-ilots-magazine-4-679x1024.jpg)
 
 ( photo Eleonore Grigon pour Ilots Magazine)
 
@@ -259,6 +259,6 @@ Elle est l'auteur du " goût silencieux , la pratique zen de la nourriture " ' A
 
 [Bio complète ici](https://www.lacuisinedelabienveillance.org/les-messagers)
 
-![This image has an empty alt attribute; its file name is Bol-de-nourriture-1-1-1024x672.jpg](assets/images/Bol-de-nourriture-1-1-1024x672.jpg)
+![This image has an empty alt attribute; its file name is Bol-de-nourriture-1-1-1024x672.jpg](/assets/images/Bol-de-nourriture-1-1-1024x672.jpg)
 
 [(](https://www.youtube.com/watch?v=VC__NTMta)photo credit: Cristelle Enault)

--- a/vault/contact.md
+++ b/vault/contact.md
@@ -5,7 +5,7 @@ authors:
   - sylvieshiweibarbier
 ---
 
-![](assets/images/aet-142-scaled.jpg)
+![](/assets/images/aet-142-scaled.jpg)
 
 ## Get in touch
 

--- a/vault/embodying-collective-intimacy.md
+++ b/vault/embodying-collective-intimacy.md
@@ -59,7 +59,7 @@ Training week: 3rd - 8th
 
 [Life Itself Praxis Hub, Bergerac](https://lifeitself.org/hubs/bergerac/), France. A palazzo in the Dordogne in the medieval town of Bergerac near Bordeaux.
 
-![View of Bergerac on the Dordogne](assets/images/ima5206798460595800666-e1653592511495.jpeg)
+![View of Bergerac on the Dordogne](/assets/images/ima5206798460595800666-e1653592511495.jpeg)
 
 ### Who is it for?
 
@@ -102,7 +102,7 @@ Our hope is that you'll find the application process to be a meaningful self-ref
 
 ## Transformational Community Residencies
 
-![Group of people gathered around a display of cards on the floor](assets/images/WhatsApp-Image-2022-01-07-at-00.19.46-e1653601766615-1024x663.jpeg)
+![Group of people gathered around a display of cards on the floor](/assets/images/WhatsApp-Image-2022-01-07-at-00.19.46-e1653601766615-1024x663.jpeg)
 
 ### **Why these community residencies?**
 
@@ -116,7 +116,7 @@ To build the capacity to do so in a meaningful and lasting way does not simply i
 
 Each month’s residency will open with a week-long intensive training on core practices to cultivate inner well-being and thriving interdependent relationships and communities. It is both a setup for the residency’s self-practice and demonstrator of the practices we are seeking to explore. The week-long training may also be booked as a stand-alone workshop.
 
-![three people meditating in sunny room](assets/images/IMG_4924_1-scaled-e1653601439702-1024x827.jpg)
+![three people meditating in sunny room](/assets/images/IMG_4924_1-scaled-e1653601439702-1024x827.jpg)
 
 ### **What we will explore**
 
@@ -159,7 +159,7 @@ Following each month’s training week, we’ll dive deeper as a micro-collectiv
 
 \* Choose one Collective Home Care slot per day
 
-![a man and a woman serve food onto plates](assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
+![a man and a woman serve food onto plates](/assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
 
 **Rest of the month**
 
@@ -179,25 +179,25 @@ Throughout the remaining time in these 3 weeks, we will construct an agenda coll
 
 _Tell me, what is it you plan to do with your one wild and precious life?_Mary Oliver
 
-![This image has an empty alt attribute; its file name is e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg](assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
+![This image has an empty alt attribute; its file name is e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg](/assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
 
 * * *
 
 ## Facilitation & Hosting Team
 
-![portrait of karl steyaert](assets/images/Karl-portrait.jpeg)
+![portrait of karl steyaert](/assets/images/Karl-portrait.jpeg)
 
 **Karl** **Steyaert** is a visionary cultural catalyst with over 25 years experience facilitating personal and collective transformation across North America, Europe and Asia. His clients range from non-profits, intentional communities and ecovillages, to universities, governments and Silicon Valley tech companies. Having designed and directed programs in Integral Sustainability for the University of Massachusetts at Findhorn Ecovillage (Scotland) and Auroville (India), as well as supporting the development of dozens of ecovillage and community projects worldwide, Karl has a passion for co-creating hubs for the evolution of consciousness and life-enriching culture. He is a certified trainer in Nonviolent Communication, and a Level 1-3 trained practitioner of Internal Family Systems therapy, as well as having extensive training and experience facilitating collective trauma healing, restorative justice, aikido, and meditation. Karl has studied directly with Marshall Rosenberg, Richard Schwartz, Thomas Hübl, Arnold Mindell, Joanna Macy, and Thich Nhat Hanh. In 2013 he founded the Cultural Catalyst Network – a global community of changemakers integrating inner, interpersonal, and systemic transformation. More on Karl at [www.karlsteyaert.com](http://www.karlsteyaert.com).
 
-![portrait of nadine helm](assets/images/Nadine-portrait.png)
+![portrait of nadine helm](/assets/images/Nadine-portrait.png)
 
 **Nadine Helm** loves contemplative practices, deep connection and presence with life and all beings. She began her study of Nonviolent Communication (NVC) in 2004, began facilitating in 2007 and is on the path to certification. Besides NVC and Living Compassion (work of Robert Gonzales), she is trained as a yoga teacher in the Sivananda tradition, yoga therapy instructor, Level 1 trained practitioner of Internal Family Systems therapy, received Mindfulness and MBSR teacher training with Tara Brach, Jack Kornfield, Joseph Goldstein, Bob Stahl and Thich Nhat Hanh. Nadine spent three years living and working in an Ashram and about 8 months at Plum Village monastery.  Nadine gives workshops and accompanies people in individual sessions on the fascinating journey into the inner world, intuitively allowing the pillars that shaped her to flow together in her work. More on Nadine at [www. embracing-life.com](https://www.embracing-life.com/).
 
-![portrait of jocelyn ames](assets/images/Jocelyn-portrait.png)
+![portrait of jocelyn ames](/assets/images/Jocelyn-portrait.png)
 
 **Jocelyn Ames** is a community catalyst with over 10 years of experience embodying a toolkit of practices for personal and collective transformation. Her inquiry into making the world a better place for all was seeded by her schooling at the United World College of Southeast Asia. After completing a BA in International Development and Geography at the School of Oriental and African Studies (London, 2012) she went on to explore more grassroots and systemic approaches to collective change and sustainability. She has dedicated many years to living and experimenting in various forms of community around the world while tending to the inner ecology of the self, the interpersonal ecology of relationship, and regenerative relationships to the earth through yoga, permaculture, Nonviolent Communication, mediation, Internal Family Systems and menstrual cycle awareness. Since 2020, she has been working alongside Karl as host and developer of the Cultural Catalyst Network, as well as being a ‘social fabric weaver’ within the Microsolidarity network. You can read more about Jocelyn at [www.becomingtogether.net](http://www.becomingtogether.net/).
 
-![portrait of catherine tran](assets/images/Catherine-portrait.png)
+![portrait of catherine tran](/assets/images/Catherine-portrait.png)
 
 **Catherine** **Tran** studied English at the University of Cambridge (UK) before completing a joint M.A. in Cultural Narratives at the University of Guelph (Canada), University of Santiago de Compostela (Spain), and University of Perpignan (France) in 2021. During her master’s she explored the role that art and literature might play in cultivating ecological responsibility, and she's currently interested in what it means to be a responsible human being in a web of interspecies interdependence. This has led her to working for Life Itself, an organization of pragmatic utopians committed to action for a radically wiser, weller world. She participated in the Cultivating Conscious Community residency facilitated by Karl at the Life Itself Hub in January 2022, which inspired her to commit to embodying collective transformation.
 
@@ -207,21 +207,21 @@ _Tell me, what is it you plan to do with your one wild and precious life?_Mary O
 
 ## Testimonials
 
-![](assets/images/4-1024x1024.png)
+![](/assets/images/4-1024x1024.png)
 
-![](assets/images/2-1024x1024.png)
+![](/assets/images/2-1024x1024.png)
 
-![](assets/images/1-1024x1024.png)
+![](/assets/images/1-1024x1024.png)
 
-![](assets/images/3-1024x1024.png)
+![](/assets/images/3-1024x1024.png)
 
-![](assets/images/4-1024x1024.png)
+![](/assets/images/4-1024x1024.png)
 
-![](assets/images/2-1024x1024.png)
+![](/assets/images/2-1024x1024.png)
 
 _The ultimate goal in life is… to become the truest expression of ourselves, to live into authentic selfhood, to honor our birthright gifts and callings, and be of service to humanity and our world._Frederic LalouxAPPLY NOW
 
-![This image has an empty alt attribute; its file name is free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg](assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
+![This image has an empty alt attribute; its file name is free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg](/assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
 
 * * *
 

--- a/vault/embodying-collective-transformation.md
+++ b/vault/embodying-collective-transformation.md
@@ -13,11 +13,11 @@ _Sharing personal and collective practices to address the challenges of our time
 
 **Bergerac, France**
 
-![community sharing meal](assets/images/IMG_0004-scaled-e1653344100902-1024x614.jpg)
+![community sharing meal](/assets/images/IMG_0004-scaled-e1653344100902-1024x614.jpg)
 
 **Thrive • Evolve • Serve**
 
-![heart squiggle and arrows](assets/images/Untitled-design-e1654193430324.png)
+![heart squiggle and arrows](/assets/images/Untitled-design-e1654193430324.png)
 
 [**Apply Now**](https://forms.gle/kiSHP72dq1agTV9Y7)
 
@@ -29,13 +29,13 @@ _Sharing personal and collective practices to address the challenges of our time
 
 A series of 3 month-long residencies consisting of a 7-day intensive training in personal and group practices for courageous collective transformation, followed by a 3-week community immersion to integrate and deepen these practices in our daily lives. The immersion includes time and space for you to continue your daily personal work and projects. Note: People can apply to attend just the week-long training, the entire month-long residency, or multiple months of residency.
 
-![group of 14 people smiling at the camera](assets/images/fullsizeoutput_1e3e-e1573491035400-1024x542.jpeg)
+![group of 14 people smiling at the camera](/assets/images/fullsizeoutput_1e3e-e1573491035400-1024x542.jpeg)
 
 ### **Why?**
 
 Our shared purpose is...
 
-![heart squiggle and arrows](assets/images/Untitled-design-e1654193430324.png)
+![heart squiggle and arrows](/assets/images/Untitled-design-e1654193430324.png)
 
 **Thrive**
 
@@ -79,7 +79,7 @@ Training week: 2nd - 7th
 
 [Life Itself Praxis Hub, Bergerac](https://lifeitself.org/hubs/bergerac/), France. A palazzo in the Dordogne in the medieval town of Bergerac near Bordeaux.
 
-![View of Bergerac on the Dordogne](assets/images/ima5206798460595800666-e1653592511495.jpeg)
+![View of Bergerac on the Dordogne](/assets/images/ima5206798460595800666-e1653592511495.jpeg)
 
 ### Who is it for?
 
@@ -124,7 +124,7 @@ Our hope is that you'll find the application process to be a meaningful self-ref
 
 ## Transformational Community Residencies
 
-![Group of people gathered around a display of cards on the floor](assets/images/WhatsApp-Image-2022-01-07-at-00.19.46-e1653601766615-1024x663.jpeg)
+![Group of people gathered around a display of cards on the floor](/assets/images/WhatsApp-Image-2022-01-07-at-00.19.46-e1653601766615-1024x663.jpeg)
 
 ### **Why these community residencies?**
 
@@ -138,7 +138,7 @@ To build the capacity to do so in a meaningful and lasting way does not simply i
 
 Each month’s residency will open with a week-long intensive training on core practices to cultivate inner well-being and thriving interdependent relationships and communities. It is both a setup for the residency’s self-practice and demonstrator of the practices we are seeking to explore. The week-long training may also be booked as a stand-alone workshop.
 
-![three people meditating in sunny room](assets/images/IMG_4924_1-scaled-e1653601439702-1024x827.jpg)
+![three people meditating in sunny room](/assets/images/IMG_4924_1-scaled-e1653601439702-1024x827.jpg)
 
 ### **What we will explore**
 
@@ -181,7 +181,7 @@ Following each month’s training week, we’ll dive deeper as a micro-collectiv
 
 \* Choose one Collective Home Care slot per day
 
-![a man and a woman serve food onto plates](assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
+![a man and a woman serve food onto plates](/assets/images/IMG_5059-scaled-e1653602699309-1024x836.jpg)
 
 **Rest of the month**
 
@@ -203,25 +203,25 @@ Throughout the remaining time in these 3 weeks, we will construct an agenda coll
 > 
 > Mary Oliver
 
-![](assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
+![](/assets/images/e1ce9022-71d8-4bae-a0dc-ecd636652497-1024x767.jpg)
 
 * * *
 
 ## Facilitation & Hosting Team
 
-![portrait of karl steyaert](assets/images/Karl-portrait.jpeg)
+![portrait of karl steyaert](/assets/images/Karl-portrait.jpeg)
 
 **Karl** **Steyaert** is a visionary cultural catalyst with over 25 years experience facilitating personal and collective transformation across North America, Europe and Asia. His clients range from non-profits, intentional communities and ecovillages, to universities, governments and Silicon Valley tech companies. Having designed and directed programs in Integral Sustainability for the University of Massachusetts at Findhorn Ecovillage (Scotland) and Auroville (India), as well as supporting the development of dozens of ecovillage and community projects worldwide, Karl has a passion for co-creating hubs for the evolution of consciousness and life-enriching culture. He is a certified trainer in Nonviolent Communication, and a Level 1-3 trained practitioner of Internal Family Systems therapy, as well as having extensive training and experience facilitating collective trauma healing, restorative justice, aikido, and meditation. Karl has studied directly with Marshall Rosenberg, Richard Schwartz, Thomas Hübl, Arnold Mindell, Joanna Macy, and Thich Nhat Hanh. In 2013 he founded the Cultural Catalyst Network – a global community of changemakers integrating inner, interpersonal, and systemic transformation. More on Karl at [www.karlsteyaert.com](http://www.karlsteyaert.com).
 
-![portrait of nadine helm](assets/images/Nadine-portrait.png)
+![portrait of nadine helm](/assets/images/Nadine-portrait.png)
 
 **Nadine Helm** loves contemplative practices, deep connection and presence with life and all beings. She began her study of Nonviolent Communication (NVC) in 2004, began facilitating in 2007 and is on the path to certification. Besides NVC and Living Compassion (work of Robert Gonzales), she is trained as a yoga teacher in the Sivananda tradition, yoga therapy instructor, Level 1 trained practitioner of Internal Family Systems therapy, received Mindfulness and MBSR teacher training with Tara Brach, Jack Kornfield, Joseph Goldstein, Bob Stahl and Thich Nhat Hanh. Nadine spent three years living and working in an Ashram and about 8 months at Plum Village monastery.  Nadine gives workshops and accompanies people in individual sessions on the fascinating journey into the inner world, intuitively allowing the pillars that shaped her to flow together in her work. More on Nadine at [www. embracing-life.com](https://www.embracing-life.com/).
 
-![portrait of jocelyn ames](assets/images/Jocelyn-portrait.png)
+![portrait of jocelyn ames](/assets/images/Jocelyn-portrait.png)
 
 **Jocelyn Ames** is a community catalyst with over 10 years of experience embodying a toolkit of practices for personal and collective transformation. Her inquiry into making the world a better place for all was seeded by her schooling at the United World College of Southeast Asia. After completing a BA in International Development and Geography at the School of Oriental and African Studies (London, 2012) she went on to explore more grassroots and systemic approaches to collective change and sustainability. She has dedicated many years to living and experimenting in various forms of community around the world while tending to the inner ecology of the self, the interpersonal ecology of relationship, and regenerative relationships to the earth through yoga, permaculture, Nonviolent Communication, mediation, Internal Family Systems and menstrual cycle awareness. Since 2020, she has been working alongside Karl as host and developer of the Cultural Catalyst Network, as well as being a ‘social fabric weaver’ within the Microsolidarity network. You can read more about Jocelyn at [www.becomingtogether.net](http://www.becomingtogether.net/).
 
-![portrait of catherine tran](assets/images/Catherine-portrait.png)
+![portrait of catherine tran](/assets/images/Catherine-portrait.png)
 
 **Catherine** **Tran** studied English at the University of Cambridge (UK) before completing a joint M.A. in Cultural Narratives at the University of Guelph (Canada), University of Santiago de Compostela (Spain), and University of Perpignan (France) in 2021. During her master’s she explored the role that art and literature might play in cultivating ecological responsibility, and she's currently interested in what it means to be a responsible human being in a web of interspecies interdependence. This has led her to working for Life Itself, an organization of pragmatic utopians committed to action for a radically wiser, weller world. She participated in the Cultivating Conscious Community residency facilitated by Karl at the Life Itself Hub in January 2022, which inspired her to commit to embodying collective transformation.
 
@@ -231,13 +231,13 @@ Throughout the remaining time in these 3 weeks, we will construct an agenda coll
 
 ## Testimonials
 
-- ![](assets/images/2-1024x1024.png)
+- ![](/assets/images/2-1024x1024.png)
     
-- ![](assets/images/1-1024x1024.png)
+- ![](/assets/images/1-1024x1024.png)
     
-- ![](assets/images/3-1024x1024.png)
+- ![](/assets/images/3-1024x1024.png)
     
-- ![](assets/images/4-1024x1024.png)
+- ![](/assets/images/4-1024x1024.png)
     
 
 > _The ultimate goal in life is… to become the truest expression of ourselves, to live into authentic selfhood, to honor our birthright gifts and callings, and be of service to humanity and our world._
@@ -246,7 +246,7 @@ Throughout the remaining time in these 3 weeks, we will construct an agenda coll
 
 [Apply Now](https://docs.google.com/forms/d/e/1FAIpQLSfHaD4-ISnoCj3qgeMOr-f-D0CD6hiHC4wnb70b7qUy8A-mJg/viewform)
 
-![](assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
+![](/assets/images/free-to-use-sounds-XtQNZRTIMYc-unsplash-1024x684.jpeg)
 
 * * *
 

--- a/vault/gathering.md
+++ b/vault/gathering.md
@@ -3,6 +3,7 @@ title: "Life Itself Summer Gathering 2022"
 created: 2020-03-17
 authors: 
   - sylvieshiweibarbier
+image: /assets/images/1909newsletter-gathering-meal-2019-1024x576-1.jpg
 ---
 
 We're excited to announce the Life Itself Summer Gathering 2022.

--- a/vault/gathering/2019-gathering.md
+++ b/vault/gathering/2019-gathering.md
@@ -31,7 +31,7 @@ Neither our society nor our planet are as well as they should be. Greater wisdom
 
 We emphasize wisdom because we believe this is about more than finding a quick-fix in technology or politics – it is about finding something deeper within ourselves and our societies.
 
-![](assets/images/ales-krivec-2892-unsplash.jpg)
+![](/assets/images/ales-krivec-2892-unsplash.jpg)
 
 ## What we will cover
 
@@ -43,7 +43,7 @@ The Gathering is a moment for the mind, heart, soul and body to meet through a p
 
 We will preserve space in the program to allow for suggestions during the week and we welcome ideas for new topics and activities in advance.
 
-![](assets/images/200710_10150234235402942_7382081_n_720x461.jpg)
+![](/assets/images/200710_10150234235402942_7382081_n_720x461.jpg)
 
 ## For whom
 
@@ -53,7 +53,7 @@ Farmers, technologists, researchers, lawyers, artists, young, old — all are we
 
 We believe this conversation needs to be open and broad so that we may enhance each other's understanding by sharing our knowledge and skills.
 
-![](assets/images/a_state_3.jpg)
+![](/assets/images/a_state_3.jpg)
 
 ## Workshops
 
@@ -73,7 +73,7 @@ Here are some examples of the practical workshops that have have held during pas
 
 **Meditation:** Follow your breath and watch your thoughts.
 
-![](assets/images/12961452_165466130514064_6522683904244243683_n_640x640.jpg)
+![](/assets/images/12961452_165466130514064_6522683904244243683_n_640x640.jpg)
 
 ## Benefits
 
@@ -89,7 +89,7 @@ Gain a broader understanding of the architecture of co-living and how this can f
 
 Explore of meditative and embodied practices.
 
-![](assets/images/1909newsletter-wanttostartyourownevent.jpg)
+![](/assets/images/1909newsletter-wanttostartyourownevent.jpg)
 
 # Discussions
 

--- a/vault/hangouts.md
+++ b/vault/hangouts.md
@@ -3,6 +3,7 @@ title: "Community Hangouts"
 created: 2021-11-03
 authors: 
   - rufuspollock
+image: /assets/images/fire_camping_campfire_group_sitting-80446.jpg
 ---
 
 - **When**: first Sunday of every month @ 6pm Europe / 12 noon US

--- a/vault/hubs.md
+++ b/vault/hubs.md
@@ -3,9 +3,10 @@ title: "Hubs"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/hubs.jpg
 ---
 
-![](assets/images/bergerac-photo_square.jpg)
+![](/assets/images/bergerac-photo_square.jpg)
 
 ##### [Thénac Farmhouse](/hubs/farmhouse/)
 
@@ -13,7 +14,7 @@ Surrounded by nature.
 
 [read more](/hubs/farmhouse/)
 
-![](assets/images/img-20200417-wa0003_square.jpg)
+![](/assets/images/img-20200417-wa0003_square.jpg)
 
 ##### [Berlin Praxis Hub](https://lifeitself.org/hubs/berlin/)
 
@@ -21,7 +22,7 @@ Intentional coliving, in Kreuzberg. 
 
 [read more](/hubs/berlin/)
 
-![](assets/images/dsc01698_square.jpg)
+![](/assets/images/dsc01698_square.jpg)
 
 ##### [Bergerac Praxis Hub](https://lifeitself.org/hubs/bergerac/)
 

--- a/vault/hubs/bergerac.md
+++ b/vault/hubs/bergerac.md
@@ -3,6 +3,7 @@ title: "The Bergerac Hub"
 created: 2020-09-28
 authors: 
   - artearthtech
+image: /assets/images/20200717_072527.jpg
 ---
 
 The Bergerac Hub offers opportunities to explore what it really means to live more consciously together.
@@ -15,11 +16,11 @@ The Hub is used both as a Life Itself Praxis Hub and is available to other group
 
 The house is finely decorated with antique furniture and a rare view onto the Dordogne. It is situated just a few steps from the river itself, and a beautiful park in a quiet area. The space is one of a kind, and its atmospheric surroundings are the perfect setting for deep exploration.
 
-![](assets/images/dordogne-view.jpg)
+![](/assets/images/dordogne-view.jpg)
 
 The gorgeous view of the Dordogne from just outside the house.
 
-![](assets/images/20200717_072527-800x1024.jpg)
+![](/assets/images/20200717_072527-800x1024.jpg)
 
 The view of the Hub from the garden.
 
@@ -27,55 +28,55 @@ The view of the Hub from the garden.
 
 The main house has a large dining room, a spacious kitchen, a spectacular living room, a separate sitting room with open fire, a gorgeous shared garden and good parking access.
 
-![](assets/images/f30dcd17-9101-4a3a-b8c6-20eea8005010-1024x768.jpeg)
+![](/assets/images/f30dcd17-9101-4a3a-b8c6-20eea8005010-1024x768.jpeg)
 
 **Dining Room** - complete with gorgeous antique furnishings, capable of comfortable seating over 20 guests.
 
-![](assets/images/fdb8a1b5-8529-44a4-ad49-aa964f67b943-1024x768.jpeg)
+![](/assets/images/fdb8a1b5-8529-44a4-ad49-aa964f67b943-1024x768.jpeg)
 
 **Painting Room** (large living room) - suitable for group meditation, workshops and other activities.
 
-![](assets/images/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce-1024x768.jpeg)
+![](/assets/images/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce-1024x768.jpeg)
 
 **Fire Room** - cozy and atmospheric, with a working fire place.
 
-![](assets/images/00278ba4-3e4a-4859-a97a-1fd2a80af860-768x1024.jpeg)
+![](/assets/images/00278ba4-3e4a-4859-a97a-1fd2a80af860-768x1024.jpeg)
 
 **Garden** - sunny and full of beautiful plant life.
 
 ## Image Gallery
 
-- [![](assets/images/img_4207.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_4207.jpg?w=580)
+- [![](/assets/images/img_4207.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_4207.jpg?w=580)
     
-- [![](assets/images/120293991_422919502013789_8779086897098183970_n.jpg)](https://artearthtech.files.wordpress.com/2020/09/120293991_422919502013789_8779086897098183970_n.jpg?w=682)
+- [![](/assets/images/120293991_422919502013789_8779086897098183970_n.jpg)](https://artearthtech.files.wordpress.com/2020/09/120293991_422919502013789_8779086897098183970_n.jpg?w=682)
     
-- [![](assets/images/dsc01698_smaller-1.jpg)](https://lifeitself.org/wp-content/uploads/2020/12/dsc01698_smaller-1.jpg)
+- [![](/assets/images/dsc01698_smaller-1.jpg)](https://lifeitself.org/wp-content/uploads/2020/12/dsc01698_smaller-1.jpg)
     
-- [![](assets/images/4bbf90d3-28a6-46bd-a2c9-de40b2bf7238-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/4bbf90d3-28a6-46bd-a2c9-de40b2bf7238-768x1024.jpeg)
+- [![](/assets/images/4bbf90d3-28a6-46bd-a2c9-de40b2bf7238-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/4bbf90d3-28a6-46bd-a2c9-de40b2bf7238-768x1024.jpeg)
     
-- [![](assets/images/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce.jpeg)
+- [![](/assets/images/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/31c1bbd4-ec30-4c39-9eb2-ccbc7e5ebcce.jpeg)
     
-- [![](assets/images/52bef2df-b245-4e2b-aecd-716320f35edb-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/52bef2df-b245-4e2b-aecd-716320f35edb.jpeg)
+- [![](/assets/images/52bef2df-b245-4e2b-aecd-716320f35edb-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/52bef2df-b245-4e2b-aecd-716320f35edb.jpeg)
     
-- [![](assets/images/00278ba4-3e4a-4859-a97a-1fd2a80af860-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/00278ba4-3e4a-4859-a97a-1fd2a80af860.jpeg)
+- [![](/assets/images/00278ba4-3e4a-4859-a97a-1fd2a80af860-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/00278ba4-3e4a-4859-a97a-1fd2a80af860.jpeg)
     
-- [![](assets/images/372bae83-cf59-4ac6-b6fd-19105c3c5075-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/372bae83-cf59-4ac6-b6fd-19105c3c5075.jpeg)
+- [![](/assets/images/372bae83-cf59-4ac6-b6fd-19105c3c5075-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/372bae83-cf59-4ac6-b6fd-19105c3c5075.jpeg)
     
-- [![](assets/images/0552db0f-14a7-43e8-a7e5-80ec73e632a6-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/0552db0f-14a7-43e8-a7e5-80ec73e632a6.jpeg)
+- [![](/assets/images/0552db0f-14a7-43e8-a7e5-80ec73e632a6-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/0552db0f-14a7-43e8-a7e5-80ec73e632a6.jpeg)
     
-- [![](assets/images/631e960b-b9ba-41ce-b0da-5b2db3a860f0.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/631e960b-b9ba-41ce-b0da-5b2db3a860f0.jpeg)
+- [![](/assets/images/631e960b-b9ba-41ce-b0da-5b2db3a860f0.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/631e960b-b9ba-41ce-b0da-5b2db3a860f0.jpeg)
     
-- [![](assets/images/44416ad1-588d-4076-9519-08157a3652ef-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/44416ad1-588d-4076-9519-08157a3652ef.jpeg)
+- [![](/assets/images/44416ad1-588d-4076-9519-08157a3652ef-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/44416ad1-588d-4076-9519-08157a3652ef.jpeg)
     
-- [![](assets/images/91380fe3-bf2c-4223-a23b-9b7479669d90-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/91380fe3-bf2c-4223-a23b-9b7479669d90.jpeg)
+- [![](/assets/images/91380fe3-bf2c-4223-a23b-9b7479669d90-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/91380fe3-bf2c-4223-a23b-9b7479669d90.jpeg)
     
-- [![](assets/images/a1b43948-e034-4c8c-b769-7fde512c31d7-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/a1b43948-e034-4c8c-b769-7fde512c31d7.jpeg)
+- [![](/assets/images/a1b43948-e034-4c8c-b769-7fde512c31d7-768x1024.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/a1b43948-e034-4c8c-b769-7fde512c31d7.jpeg)
     
-- [![](assets/images/a4aae6fe-0c9b-4884-888a-cc10d1ce5cf3-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/a4aae6fe-0c9b-4884-888a-cc10d1ce5cf3.jpeg)
+- [![](/assets/images/a4aae6fe-0c9b-4884-888a-cc10d1ce5cf3-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/a4aae6fe-0c9b-4884-888a-cc10d1ce5cf3.jpeg)
     
-- [![](assets/images/f30dcd17-9101-4a3a-b8c6-20eea8005010-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/f30dcd17-9101-4a3a-b8c6-20eea8005010.jpeg)
+- [![](/assets/images/f30dcd17-9101-4a3a-b8c6-20eea8005010-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/f30dcd17-9101-4a3a-b8c6-20eea8005010.jpeg)
     
-- [![](assets/images/fdb8a1b5-8529-44a4-ad49-aa964f67b943-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/fdb8a1b5-8529-44a4-ad49-aa964f67b943.jpeg)
+- [![](/assets/images/fdb8a1b5-8529-44a4-ad49-aa964f67b943-1024x768.jpeg)](https://lifeitself.org/wp-content/uploads/2021/07/fdb8a1b5-8529-44a4-ad49-aa964f67b943.jpeg)
     
 
 ## Bedrooms
@@ -90,19 +91,19 @@ There are three types of bedroom: basic, standard, premium. Basic are still func
 
 Our smallest rooms are still pleasantly furnished, just without the bells and whistles. Single beds throughout.
 
-![](assets/images/f49639c6-fab0-480d-80a8-a1b0855015ce-768x1024.jpeg)
+![](/assets/images/f49639c6-fab0-480d-80a8-a1b0855015ce-768x1024.jpeg)
 
 ### Standard
 
 Generously sized with double beds throughout and still impressively furnished. No ensuite bathrooms but easy bathroom access.
 
-![](assets/images/52bef2df-b245-4e2b-aecd-716320f35edb-1024x768.jpeg)
+![](/assets/images/52bef2df-b245-4e2b-aecd-716320f35edb-1024x768.jpeg)
 
 ### Premium
 
 Generally ensuite. Large. May have special features e.g. a balcony or particular view.
 
-![](assets/images/4c59d26e-c278-4932-a9b2-4a23fe4f4acb-768x1024.jpeg)
+![](/assets/images/4c59d26e-c278-4932-a9b2-4a23fe4f4acb-768x1024.jpeg)
 
 ## Amenities
 
@@ -130,7 +131,7 @@ The address of the Hub is 11 Place Barbacane, Bergerac, 24100, France.
 
 You can view the correct location on the map below:
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2828.721257497998!2d0.47933471562071056!3d44.84760968239347!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12aada824e2f1507%3A0x8ad8c625e2f99200!2s11%20Pl.%20Barbacane%2C%2024100%20Bergerac%2C%20France!5e0!3m2!1sen!2suk!4v1630575848887!5m2!1sen!2suk" width="600" height="450" style={{border:0}}" allowFullScreen loading="lazy"></iframe>
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2828.721257497998!2d0.47933471562071056!3d44.84760968239347!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12aada824e2f1507%3A0x8ad8c625e2f99200!2s11%20Pl.%20Barbacane%2C%2024100%20Bergerac%2C%20France!5e0!3m2!1sen!2suk!4v1630575848887!5m2!1sen!2suk" width="600" height="450" style={{border:0}} allowfullscreen loading="lazy"></iframe>
 
 #### By train 🚆
 

--- a/vault/hubs/berlin.md
+++ b/vault/hubs/berlin.md
@@ -3,6 +3,7 @@ title: "Berlin"
 created: 2020-06-23
 authors: 
   - rufuspollock
+image: /assets/images/berlin-hub-2.jpg
 ---
 
 ## 19th century building. 21st century living 
@@ -25,29 +26,29 @@ As a relatively new community, now’s the time to shape our culture, and we nee
 
 The bedrooms in the Berlin Hub are relatively large, and we offer a range of accommodation, from single bedrooms to studio apartments, to suit your needs. Prices start from €560 per calendar month.
 
-- [![](assets/images/aet4f_20200504_120528.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120528.jpg?w=580)
+- [![](/assets/images/aet4f_20200504_120528.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120528.jpg?w=580)
     
-- [![](assets/images/copy-of-img_1978.jpeg)](https://artearthtech.files.wordpress.com/2020/06/copy-of-img_1978.jpeg)
+- [![](/assets/images/copy-of-img_1978.jpeg)](https://artearthtech.files.wordpress.com/2020/06/copy-of-img_1978.jpeg)
     
-- [![](assets/images/aet4f_20200504_120441.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120441.jpg?w=1024)
+- [![](/assets/images/aet4f_20200504_120441.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120441.jpg?w=1024)
     
-- [![](assets/images/img-20200417-wa0003.jpg)](https://artearthtech.files.wordpress.com/2020/06/img-20200417-wa0003.jpg)
+- [![](/assets/images/img-20200417-wa0003.jpg)](https://artearthtech.files.wordpress.com/2020/06/img-20200417-wa0003.jpg)
     
-- [![](assets/images/aet4f_20200504_120631.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120631.jpg?w=1024)
+- [![](/assets/images/aet4f_20200504_120631.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120631.jpg?w=1024)
     
-- [![](assets/images/aet4f_20200504_120714.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120714.jpg?w=1024)
+- [![](/assets/images/aet4f_20200504_120714.jpg)](https://artearthtech.files.wordpress.com/2020/06/aet4f_20200504_120714.jpg?w=1024)
     
-- [![](assets/images/soenke_niemann_1.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_1.jpg?w=580)
+- [![](/assets/images/soenke_niemann_1.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_1.jpg?w=580)
     
-- [![](assets/images/soenke_niemann_7.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_7.jpg?w=580)
+- [![](/assets/images/soenke_niemann_7.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_7.jpg?w=580)
     
-- [![](assets/images/soenke_niemann_6.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_6.jpg?w=580)
+- [![](/assets/images/soenke_niemann_6.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_6.jpg?w=580)
     
-- [![](assets/images/soenke_niemann_5.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_5.jpg?w=580)
+- [![](/assets/images/soenke_niemann_5.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_5.jpg?w=580)
     
-- [![](assets/images/soenke_niemann_4.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_4.jpg?w=580)
+- [![](/assets/images/soenke_niemann_4.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_4.jpg?w=580)
     
-- [![](assets/images/soenke_niemann_3.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_3.jpg?w=580)
+- [![](/assets/images/soenke_niemann_3.jpg)](https://artearthtech.files.wordpress.com/2020/07/soenke_niemann_3.jpg?w=580)
     
 
 Photos Credits: Life Itself and Soenke Niemann

--- a/vault/hubs/farmhouse.md
+++ b/vault/hubs/farmhouse.md
@@ -3,27 +3,28 @@ title: "Farmhouse"
 created: 2020-08-11
 authors: 
   - sophie84d503f875
+image: /assets/images/bergerac-photo-1.jpg
 ---
 
 ## Surrounded by nature
 
 The Farmhouse is situated in peaceful, natural surroundings just 5 minutes drive from Plum Village Monastery and 20 minutes from the Dordogne River. See [how to find us](https://lifeitself.org/how-to-find-us/) for more information on the location and instructions for getting here.
 
-- [![](assets/images/20190618_152631.jpg)](https://artearthtech.files.wordpress.com/2020/08/20190618_152631.jpg)
+- [![](/assets/images/20190618_152631.jpg)](https://artearthtech.files.wordpress.com/2020/08/20190618_152631.jpg)
     
-- [![](assets/images/img_20200825_205219-1.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200825_205219-1.jpg?w=580)
+- [![](/assets/images/img_20200825_205219-1.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200825_205219-1.jpg?w=580)
     
-- [![](assets/images/qodutnz.jpg)](https://artearthtech.files.wordpress.com/2020/09/qodutnz.jpg?w=580)
+- [![](/assets/images/qodutnz.jpg)](https://artearthtech.files.wordpress.com/2020/09/qodutnz.jpg?w=580)
     
-- [![](assets/images/img_20200823_200544.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200823_200544.jpg?w=580)
+- [![](/assets/images/img_20200823_200544.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200823_200544.jpg?w=580)
     
-- [![](assets/images/img_20200822_102408.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200822_102408.jpg?w=580)
+- [![](/assets/images/img_20200822_102408.jpg)](https://artearthtech.files.wordpress.com/2020/09/img_20200822_102408.jpg?w=580)
     
-- [![](assets/images/whatsapp-image-2020-08-19-at-14.40.11-1.jpg)](https://artearthtech.files.wordpress.com/2020/09/whatsapp-image-2020-08-19-at-14.40.11-1.jpg?w=580)
+- [![](/assets/images/whatsapp-image-2020-08-19-at-14.40.11-1.jpg)](https://artearthtech.files.wordpress.com/2020/09/whatsapp-image-2020-08-19-at-14.40.11-1.jpg?w=580)
     
-- [![](assets/images/bergerac-photo-1-1-1024x768.jpg)](https://lifeitself.org/wp-content/uploads/2020/12/bergerac-photo-1-1.jpg)
+- [![](/assets/images/bergerac-photo-1-1-1024x768.jpg)](https://lifeitself.org/wp-content/uploads/2020/12/bergerac-photo-1-1.jpg)
     
-- [![](assets/images/115811446_1215685965443545_7392111846893456331_n1.jpg)](https://artearthtech.files.wordpress.com/2020/08/115811446_1215685965443545_7392111846893456331_n1.jpg?w=580)
+- [![](/assets/images/115811446_1215685965443545_7392111846893456331_n1.jpg)](https://artearthtech.files.wordpress.com/2020/08/115811446_1215685965443545_7392111846893456331_n1.jpg?w=580)
     
 
 ## Your future home

--- a/vault/hubs/london.md
+++ b/vault/hubs/london.md
@@ -11,7 +11,7 @@ The London Hub unites creatives, thinkers, and entrepreneurs committed to wiser,
 
 [Enquire Now](https://lifeitself.org/contact/)
 
-- ![](assets/images/sink_hu90cd9d2dd4bb321e2af7088a8a51154a_1742362_800x0_resize_box_2.png)
+- ![](/assets/images/sink_hu90cd9d2dd4bb321e2af7088a8a51154a_1742362_800x0_resize_box_2.png)
     
 
 ## Northern line on your doorstep
@@ -34,15 +34,15 @@ Our communal kitchen and living spaces have been designed to give you everything
 
 Our events programme is run by you, the community, so whether it’s foreign film night or a workshop on permaculture, you’re in charge.  
 
-- ![](assets/images/shower_hu307a9479e74e4ae4080f9415888abb86_678135_800x0_resize_box_2-1.png)
+- ![](/assets/images/shower_hu307a9479e74e4ae4080f9415888abb86_678135_800x0_resize_box_2-1.png)
     
-- ![](assets/images/kitchen_hucbce3a5f1e988cfeacf665e2242fb684_580923_800x0_resize_box_2.png)
+- ![](/assets/images/kitchen_hucbce3a5f1e988cfeacf665e2242fb684_580923_800x0_resize_box_2.png)
     
-- ![](assets/images/sitting-room-couch_hu271c426a86158d4fc85a3b4d17cee625_1137761_800x0_resize_box_2.png)
+- ![](/assets/images/sitting-room-couch_hu271c426a86158d4fc85a3b4d17cee625_1137761_800x0_resize_box_2.png)
     
-- ![](assets/images/sink_hu90cd9d2dd4bb321e2af7088a8a51154a_1742362_800x0_resize_box_2.png)
+- ![](/assets/images/sink_hu90cd9d2dd4bb321e2af7088a8a51154a_1742362_800x0_resize_box_2.png)
     
-- ![](assets/images/sitting-room_hue5d0803c3774a40d4d61bd93f0557694_1109817_800x0_resize_box_2.png)
+- ![](/assets/images/sitting-room_hue5d0803c3774a40d4d61bd93f0557694_1109817_800x0_resize_box_2.png)
     
 
 [Enquire now](https://lifeitself.org/contact/)

--- a/vault/insight-interbeing-and-science-may-2022.md
+++ b/vault/insight-interbeing-and-science-may-2022.md
@@ -25,7 +25,7 @@ In this residency we will humbly consider the possibility raised above by Thich 
 - **Interested?** [Apply now »](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 - **Have questions?** email liam@lifeitself.org
 
-![](assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
+![](/assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
 
 ## Overview
 

--- a/vault/institute.md
+++ b/vault/institute.md
@@ -3,6 +3,7 @@ title: "Institute"
 created: 2020-03-09
 authors: 
   - artearthtech
+image: /assets/images/a_state_1.jpg
 ---
 
 ## Our Purpose

--- a/vault/institute/compassionate-mental-health.md
+++ b/vault/institute/compassionate-mental-health.md
@@ -3,6 +3,7 @@ title: "Compassionate Mental Health"
 created: 2021-05-14
 authors: 
   - rufuspollock
+image: /assets/images/mike-erskine-S_VbdMTsdiA-unsplash-scaled.jpg
 ---
 
 ### Coming Home to Ourselves

--- a/vault/institute/contemplative-activism.md
+++ b/vault/institute/contemplative-activism.md
@@ -3,13 +3,14 @@ title: "Contemplative Activism"
 created: 2020-05-19
 authors: 
   - liamaet
+image: /assets/images/ills-of-cap.jpg
 ---
 
 Contemplative Activism is the realisation that one of the wellsprings of our social and personal pain and confusion is the lack of a contemplative mindset -- the mindset we are in when we are "connected." Contemplative activism means doing the activism that we already do, such as climate activism, with a contemplative or reflective mindset. It also involves asking ourselves how to be activist on behalf of the contemplative mindset -- to give our wholeness its central place in our lives, organisations, and in society.
 
 We see many expressions of contemplative pursuits such as mindfulness, embodied movement, and trauma healing to name a few. We are collectively exploring contemplative pursuits' of intertwinedness, and co-creating a space for these related pursuits to make each other more whole and more effective.
 
-- ![](assets/images/img_20200419_131056.jpg)
+- ![](/assets/images/img_20200419_131056.jpg)
     
 
 Please join us for our weekly call where our nascent, irreligious Sangha meets. We are currently exploring themes such as suffering, racism, and denial, with a generous smattering of recipes and other inquiries into our human condition.

--- a/vault/jobs.md
+++ b/vault/jobs.md
@@ -3,6 +3,7 @@ title: "Jobs"
 created: 2020-09-22
 authors: 
   - sophie84d503f875
+image: /assets/images/institute_stef_ruf_resized.jpg
 ---
 
 ##### We don't have any specific openings at the moment. Nonetheless, we're always keen to hear from interesting and aligned individuals, so if you think you could help advance the Life Itself mission then please use the link below to get in touch.

--- a/vault/light-shadow-integration.md
+++ b/vault/light-shadow-integration.md
@@ -26,7 +26,7 @@ And much else besides…. Participants will be invited to bring their own practi
 - **Interested?** [Apply now »](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 - **Have questions?** email liam@lifeitself.org
 
-![](assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
+![](/assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
 
 ## Overview
 

--- a/vault/ontological-politics.md
+++ b/vault/ontological-politics.md
@@ -3,6 +3,7 @@ title: "Ontological Politics"
 created: 2021-02-26
 authors: 
   - rufuspollock
+image: /assets/images/ethan-hoover-325423-unsplash-scaled.jpg
 ---
 
 ## An integral politics grounded in the nature of being for human beings.
@@ -15,7 +16,7 @@ For example, much of modern economic and political thought rests on the assumpti
 
 Ontological Politics starts from the question: who are we as humans _beings_. And from that asks what politics comes from that i.e. what social and collective would we seek. It incorporates ideas from philosophy, wisdom traditions, technology and cognitive science connecting these to a new value based political movement and programme for wiser society.
 
-![](assets/images/image_2021-04-16_172851-1024x570.png)
+![](/assets/images/image_2021-04-16_172851-1024x570.png)
 
 ## Ontological Politics Outline v1 (Winter 2020)
 
@@ -37,7 +38,7 @@ _An initiative of the COVID-era._
 
 [https://possibilitynow.lifeitself.org](https://possibilitynow.lifeitself.org)
 
-![](assets/images/Opera-Snapshot_2021-11-17_205152_possibilitynow.lifeitself.org_-1024x586.png)
+![](/assets/images/Opera-Snapshot_2021-11-17_205152_possibilitynow.lifeitself.org_-1024x586.png)
 
 _Subscribe_ _to our mailing list to be kept up-to-date with future activities_
 

--- a/vault/open-residency.md
+++ b/vault/open-residency.md
@@ -11,7 +11,7 @@ authors:
 
 [Apply now](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 
-![](assets/images/Blog-Feature-Images-9-1024x576.png)
+![](/assets/images/Blog-Feature-Images-9-1024x576.png)
 
 ## Key Info
 
@@ -67,13 +67,13 @@ Valerie and Marc will welcome you and be the guardians of MVP ( minimum Viable p
 
 ### Valérie Duvauchelle (first 3 weeks)
 
-![](assets/images/star-portrait--1024x683.jpg)
+![](/assets/images/star-portrait--1024x683.jpg)
 
 Pioneer of Life Itself since 2020 as the daily collective practices guardian of the Hub, Valerie is also the steward of the Bergerac Praxis Hub . Trained in zen soto lineage as a cook ( tenzo) she is passionate about the question of food and open spaces to sit in its complexity . She is facilitating regular food trainings and retreats to help cooks to expand their practice and takes care of the food system of the hub.
 
 ##### Marc Santolini (last week)
 
-![](assets/images/event_image-58e4e9144dacebaa7d011553573fbeab.jpg)
+![](/assets/images/event_image-58e4e9144dacebaa7d011553573fbeab.jpg)
 
 Marc Santolini is a researcher at the Learning Planet Institute where he uses network science to investigate how groups innovate, collaborate and learn, with a particular focus on open and citizen science and the open-source movement. He is also a co-founder of the Just One Giant Lab NGO that equips emergent open research communities with a virtual space and tools to thrive. Fascinated by the emergence of higher-order simplicity out of complex interactions, he also explores how group rituals and facilitations mechanisms help achieve a collective flow state, and has developed embodied sound-based resonance practices to experience our shared interbeing.
 

--- a/vault/pioneering-culture.md
+++ b/vault/pioneering-culture.md
@@ -3,6 +3,7 @@ title: "Pioneering Culture"
 created: 2021-04-28
 authors: 
   - theo-cox
+image: /assets/images/haseeb-jamil-zbg2-gyo_hM-unsplash-scaled.jpg
 ---
 
 Our pioneering a culture is focused on bottom up change through local intervention. Under this pillar we are creating a sustainable network of communities within existing society through [hubs](https://lifeitself.org/hubs/) and businesses that are pioneering an “awakening” culture – waking up, cleaning up, growing up (teal) and showing up. These would act as a home for members, an engine for our movement and a demonstrator of a new vision for society.

--- a/vault/previous-residencies.md
+++ b/vault/previous-residencies.md
@@ -3,6 +3,7 @@ title: "Previous Residencies"
 created: 2022-10-27
 authors: 
   - eilidhross
+image: /assets/images/Blog-Feature-Images-29.jpg
 ---
 
 ## Our Past Residencies

--- a/vault/real-estate-fund.md
+++ b/vault/real-estate-fund.md
@@ -3,6 +3,7 @@ title: "Real Estate-fund"
 created: 2020-08-12
 authors: 
   - artearthtech
+image: /assets/images/15030017-scaled.jpg
 ---
 
 The Fund exists to provide capital to develop mindful, wiser and weller co-living and co-housing communities, whilst providing investors with an opportunity for social impact, security of capital and a fair return.
@@ -15,7 +16,7 @@ You are investing in one of the safest assets: land and property. Income is base
 
 We practice ethical management with a long-term vision for the Fund and investors. We define maximum and minimum salary packages, do not use bonus incentives, and employ a not-for-profit management approach. We are inspired by the mindfulness trainings of Thich Nhat Hanh, founder of the Plum Village Monastery, and believe them to be an accurate compass with which to steward the fund. In this vein, we are committed to a regular mindfulness practice and to engage in ongoing personal and professional development.
 
-![](assets/images/bergerac-photo-1.jpg)
+![](/assets/images/bergerac-photo-1.jpg)
 
 ## Enabling Wiser, Weller Living
 

--- a/vault/relation-a-largent-et-histoires-de-vie.md
+++ b/vault/relation-a-largent-et-histoires-de-vie.md
@@ -66,7 +66,7 @@ Participer à l'expérience globale de la résidence de l'intelligence collectiv
 
 Rime LOUHAICHI
 
-![](assets/images/GraphiqueColle-1.png)
+![](/assets/images/GraphiqueColle-1.png)
 
 J’accompagne l’élément humain au quotidien dans mes pratiques depuis près de 25 ans. Que ce soit par le biais des fonctions RH que j’ai exercées pendant 15 ans, la facilitation en intelligence collective, le co-développement, la communication non violente, le coaching, l’approche narrative, j’ai à cœur de permettre l’émergence de nos multiples intelligences, l’accueil de nos ressentis, l’écriture de récits alternatifs, collectifs et résilients. De cette traversée commune, se vit et s’expérimente profondément nos liens visibles et invisibles, singuliers et universels.
 

--- a/vault/requiem.md
+++ b/vault/requiem.md
@@ -3,6 +3,7 @@ title: "Requiem for a Passing Age<br /><br />To create a future, we need to comp
 created: 2022-05-24
 authors: 
   - rufuspollock
+image: /assets/images/ruben-ortega-viel7n9kgNA-unsplash-scaled.jpg
 ---
 
 Oh silence.  

--- a/vault/state-of-sensemaking-2020.md
+++ b/vault/state-of-sensemaking-2020.md
@@ -3,6 +3,7 @@ title: "State of Sensemaking 2020"
 created: 2021-09-02
 authors: 
   - theo-cox
+image: /assets/images/Social_Change_Ecosystem.png
 ---
 
 This report is our first output from [our ongoing efforts to map the ecosystem in which we exist](/ecosystem/). The ecosystem is still emerging and ill-defined. Reflecting this there is no clear name for it and we have settled, not entirely happily on the “state of sensemaking”.
@@ -29,7 +30,7 @@ Download the full report below to read our analysis, and find out more about sel
 
 Our overview map from our preliminary research. To explore the diagram in more detail [visit the full interactive version on coggle](https://coggle.it/diagram/YR_QUHIgSTQ5i8Oc/t/social-change-ecosystem).
 
-![](assets/images/Social_Change_Ecosystem-1024x626.png)
+![](/assets/images/Social_Change_Ecosystem-1024x626.png)
 
 ## Credits
 

--- a/vault/subscribe.md
+++ b/vault/subscribe.md
@@ -18,7 +18,7 @@ authors:
 
 By subscribing you agree to our [privacy policy](/privacy-policy). You may unsubscribe at any time.
 
-![ebook](assets/images/eBook-mockup.webp)
+![ebook](/assets/images/eBook-mockup.webp)
 
 ### A welcome gift when you subscribe
 
@@ -30,7 +30,7 @@ A contemplative essay about an unseen force which feels eerily familiar: the out
 
 By subscribing you agree to our [privacy policy](/privacy-policy). You may unsubscribe at any time.
 
-[![logo](assets/images/life-itself-logo-black.png)
+[![logo](/assets/images/life-itself-logo-black.png)
 
 ##### Life Itself
 

--- a/vault/sympoiesis.md
+++ b/vault/sympoiesis.md
@@ -5,7 +5,7 @@ authors:
   - liamaet
 ---
 
-![](assets/images/image-1024x865.png)
+![](/assets/images/image-1024x865.png)
 
 # Context
 

--- a/vault/sympoiesis/1-daily-collective-practices-oct-nov-2021.md
+++ b/vault/sympoiesis/1-daily-collective-practices-oct-nov-2021.md
@@ -1,5 +1,5 @@
 ---
-title: "Sympoiesis #1: Daily collective practices 15 Oct to 14 Nov 2021"
+title: "Sympoiesis #1:<br>Daily collective practices<br>15 Oct to 14 Nov 2021"
 created: 2021-09-06
 authors: 
   - rufuspollock
@@ -7,7 +7,7 @@ authors:
 
 ## **Question: How can collective practices in everyday life nourish a way of being-withness in the world?**
 
-![](assets/images/20210402_082033-768x1024.jpg)
+![](/assets/images/20210402_082033-768x1024.jpg)
 
 # **Introduction**
 
@@ -78,7 +78,7 @@ We are a Lab of practices and want to experience the effect of the collective bo
 
 ## Tenzo retreat /21th-24th october 2021 
 
-![](assets/images/IMG_0686-2-768x1024.jpeg)
+![](/assets/images/IMG_0686-2-768x1024.jpeg)
 
 **To participate to the Tenzo retreat please click** [https://ti.to/praxis-hub/sympoiesis-1-daily-collective-practices](https://ti.to/praxis-hub/sympoiesis-1-daily-collective-practices)
 
@@ -86,7 +86,7 @@ As the food is at the heart of both joy and pain of our world we will explore wh
 
 Valerie Dai Hatsu  has been practicing the shojin ryori ( zen cooking) in zen  monastic temples in Japan for 10 years  and  carries the enthusiasm to share it  in the secular world. More info on her website : [http://lacuisinedelabienveillance.org](http://lacuisinedelabienveillance.org)
 
-![](assets/images/IMG_0002-1024x683.jpg)
+![](/assets/images/IMG_0002-1024x683.jpg)
 
 photo Prem Krishnamurthy
 
@@ -114,7 +114,7 @@ Formal retreat will start the 28th at 7 pm and finish the 1st at 3 pm.
 
 **Valerie Dai Hatsu Duvauchelle**  is a guardian of the Zen tradition and practices the tenzo path . Member of the Collective Intelligence Cooperative [( MIC](https://coomic.coop/site/)) , she offers to communities workshops of Work That reconnects and food practices coaching. she also explores the frontier of contemplation and activism through contemplative activism .She is the author of "Goût silencieux, la pratique zen de la nourriture" published by Actes sud.
 
-![](assets/images/ValerieDuvauchelle-9©sophie-lavaur-2-1024x683.jpg)
+![](/assets/images/ValerieDuvauchelle-9©sophie-lavaur-2-1024x683.jpg)
 
 **Jean Nyojo Rat**  is a Buddhist monk in the Zen tradition, a father of two and an active listener coach. He devotes himself to simple sitting, sewing the kesa and studying the teachings, practising their deployment in daily life.
 

--- a/vault/sympoiesis/3-cultivating-conscious-community-jan-2022.md
+++ b/vault/sympoiesis/3-cultivating-conscious-community-jan-2022.md
@@ -25,7 +25,7 @@ authors:
 - **Notes on costs:** our aim is that cost is not an obstacle to anyone in participating. If finance is an issue please get in touch and we will see if we can provide support in some way or another.
 - **Interested?** [Apply now »](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 
-![](assets/images/gathering-meal-2019-1024x576.jpg)
+![](/assets/images/gathering-meal-2019-1024x576.jpg)
 
 Please find out about our **[common principles](https://lifeitself.org/sympoiesis/#Common_principles_please_read_carefully) which need to be agreed on** before coming.
 
@@ -87,25 +87,25 @@ Some may already have a background in some or all of these practices, and that i
 > 
 > – An Van Damme, Workshop Participant and Process Facilitator
 
-![](assets/images/AnVanDamme_rond.png)
+![](/assets/images/AnVanDamme_rond.png)
 
 > _I appreciated the magic, the warmth, the safe space to be seen and see others with an open heart, the inspiring facilitation by Karl, tangible skills (NVC distinctions, Parts Work, empathy, dialogue practices come to mind first), embodied experiences of these skills and ways of being, personal transformation, and a reminder of the beauty of community._
 > 
 > – Corinna Zuckerman, Workshop Participant and Social Entrepreneur
 
-![](assets/images/Mercator-Kolleg_2013_2780-edited.jpg)
+![](/assets/images/Mercator-Kolleg_2013_2780-edited.jpg)
 
 ## Facilitators
 
 ### Karl Steyaert
 
-![](assets/images/image_2021-10-30_151727.png)
+![](/assets/images/image_2021-10-30_151727.png)
 
 Karl is a visionary cultural catalyst with over 25 years experience facilitating personal and collective transformation across North America, Europe and Asia. His clients range from universities and ecovillages, to metropolitan governments and Silicon Valley tech companies such as Netflix. Having designed and directed university programs in Integral Sustainability at Findhorn Ecovillage (Scotland) and Auroville (India), as well as supporting the development of dozens of ecovillage and community projects worldwide, Karl has a passion for co-creating hubs for the evolution of consciousness and life-enriching culture. He is a certified trainer in Nonviolent Communication, and a trained practitioner of Internal Family Systems therapy, collective trauma healing, restorative justice, aikido, and meditation. In 2013 he founded the Cultural Catalyst Network – a global community of change makers integrating inner, interpersonal, and systemic transformation.
 
 ## Rufus Pollock
 
-![](assets/images/rufus-Cropped.jpg)
+![](/assets/images/rufus-Cropped.jpg)
 
 Rufus is one of the co-founders of Life Itself and co-curator of the Praxis Hub in Bergerac. He has been engaged both with community and transformative practice for over two decades as a Zen student and a leader at Landmark. As well as being passionate about transformative community, Rufus has also been an active social entrepreneur and researcher founding and growing a variety of non-profit initiatives as well as teaching economics at the University of Cambridge.
 

--- a/vault/sympoiesis/4-collective-intelligence-feb-mar-2022.md
+++ b/vault/sympoiesis/4-collective-intelligence-feb-mar-2022.md
@@ -9,7 +9,7 @@ L'intelligence collective comme clef de changement sociétal
 
 ### Questionner, explorer et pratiquer l'intelligence collective
 
-![](assets/images/20210228_105800-1024x576.jpg)
+![](/assets/images/20210228_105800-1024x576.jpg)
 
 ## Info Clés
 
@@ -51,7 +51,7 @@ Il est attendu de la part des participants de la residence qu'ils participent é
 
 - **Intéressé.e ?** [je me préinscris](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 
-![](assets/images/transmettre.png)
+![](/assets/images/transmettre.png)
 
 L'idée de cette résidence est de combiner une expérience du vivre ensemble en intelligence collective et de partager la technologie de l'intelligence collective sous forme de stages .Vivre en communauté est une belle opportunité d’explorer les multiples champs d’application possible de l’intelligence collective dans nos vies et d'intégrer les outils de l'intelligence collective à notre quotidien .
 
@@ -87,7 +87,7 @@ Pour en savoir plus sur les résidences du Praxis hub de bergerac , cliquez sur 
 
 ## Les repas au Hub
 
-![](assets/images/IMG_3591-1024x1024.jpg)
+![](/assets/images/IMG_3591-1024x1024.jpg)
 
 Le budget de base de €8 euros repose sur des menus composés d'une céréale neutre , un plat incluant des protéines végétales/ légumes et une salade crue avec le maximum de variétés, couleurs et textures ainsi qu'un dessert et cookies . Aucun repas collectif n'utilisera de produits animaux toutefois il sera possible d'intégrer des produits animaux en conscience ( traçabilité éthique ) et selon des modalités qui seront définies en intelligence collective .
 

--- a/vault/sympoiesis/conscious-food-retreats-culture-broths-1.md
+++ b/vault/sympoiesis/conscious-food-retreats-culture-broths-1.md
@@ -11,7 +11,7 @@ authors:
 
 How do we seed new narratives?
 
-![](assets/images/ee2766221bc99af791d15d70fd87990e.jpg)
+![](/assets/images/ee2766221bc99af791d15d70fd87990e.jpg)
 
 ## Key Info
 
@@ -84,7 +84,7 @@ Here is the general frame of this retreat:
 
 ##### Valérie Duvauchelle 
 
-![](assets/images/011_11A-679x1024.jpg)
+![](/assets/images/011_11A-679x1024.jpg)
 
 Valérie is a pioneer within Life Itself and head curator of the Bergerac Praxis hub. Her passion is to create enabling frameworks that allow a different relationship to the world and to oneself in order to live fully. She is passionate about community and seeks to understand the invisible evolutionary mechanisms that occur when we do things together. She is a Tenzo (cook) in the Zen tradition; her practice is part of the movement of "being with" in just sitting and just cooking.
 

--- a/vault/sympoiesis/emergent-dialogue-residency-june-2022.md
+++ b/vault/sympoiesis/emergent-dialogue-residency-june-2022.md
@@ -3,6 +3,7 @@ title: "Emergent Dialogue Residency - June 2022"
 created: 2022-03-01
 authors: 
   - rufuspollock
+image: /assets/images/Page-Feature-Images.jpg
 ---
 
 ###### [April 2022 update: DATE TBD. This residency was originally scheduled to take place in June 2022. It will now take place at a later date. Be the first to know when a new date is confirmed by signing up to our newsletter.](https://lifeitself.org/contact/)
@@ -13,7 +14,7 @@ authors:
 
 #### How can we cohere our autonomy and uniqueness to live and create at the edge of emergence?
 
-[Apply Now](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform) [Read Key Info](#key-info) ![](assets/images/cropped-cropped-life-itself-horizontal.png)
+[Apply Now](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform) [Read Key Info](#key-info) ![](/assets/images/cropped-cropped-life-itself-horizontal.png)
 
 ###### June 2022, Bergerac, France
 
@@ -23,11 +24,11 @@ authors:
 
 ##### Led by Elizabeth Debold & Thomas Steininger
 
-![](assets/images/Thomas-Eliz-Side-Assisi-2020.jpg)
+![](/assets/images/Thomas-Eliz-Side-Assisi-2020.jpg)
 
 ##### For more info: https://lifeitself.org/emergent-dialogue/
 
-![](assets/images/IMG_1534-1024x1024.jpeg) ![](assets/images/small-meditator-5.png) ![](assets/images/Fall-Equinox-Fire-Ceremony-2018-2-1024x1024.jpg) ![](assets/images/emerge-SWG-fire-circle-Pfingsten-2018-2-1024x1024.jpeg)
+![](/assets/images/IMG_1534-1024x1024.jpeg) ![](/assets/images/small-meditator-5.png) ![](/assets/images/Fall-Equinox-Fire-Ceremony-2018-2-1024x1024.jpg) ![](/assets/images/emerge-SWG-fire-circle-Pfingsten-2018-2-1024x1024.jpeg)
 
 ## Key Info
 
@@ -75,7 +76,7 @@ Moreover, we don’t want to (and can’t) “go back” to pre-individuated col
 
 Where do we turn? Already, human beings are being moved to seek connection and connectedness beyond the separate self. Efforts to end the divisions of racism and sexism are part of this desire. The mindfulness revolution of the last forty years has been a powerful impulse to free the self from separation. And the craving for community, for co-working and co-living and co-creation, is growing stronger and finding new expression in remarkable social and organizational experiments.
 
-![](assets/images/Rectangle-3-1.png) How can we cohere our autonomy and individuality within a greater collective whole?  
+![](/assets/images/Rectangle-3-1.png) How can we cohere our autonomy and individuality within a greater collective whole?  
   
   
 Can we individually contribute to and collectively tap into a new, synergetic intelligence and awareness?  
@@ -105,7 +106,7 @@ Is there a collective creativity in which the unique contribution of each indivi
 
 If this intrigues you and you would like to experiment with a new potential that transcends and includes our individual creativity, you may now have the question: How do I find out more about this? How do I learn and practice this?
 
-![](assets/images/Rectangle-3-2-1-1024x341.png)
+![](/assets/images/Rectangle-3-2-1-1024x341.png)
 
 Come to this 7-day intensive workshop and residency led by the global pioneers of _emergent dialogue,_ Thomas Steininger and Elizabeth Debold, to open yourself to the co-conscious creativity of the living space between us, hosted in a beautiful villa in the southwest of France in full-bloom June.
 
@@ -221,53 +222,53 @@ After a few residencies at Life itself, we have come to realize how important th
 
 The residency will also be a field of experimentation. We will continue to explore the new capacities that emergent dialogue opens up in a variety of contexts: to develop a creative project together, to think deeply together about current issues, and to reveal shadow aspects of the self. Our aim during this month together is to bring to life a vital, creative community that allows us to experience being a living, creative field that transcends and includes our uniqueness.
 
-![](assets/images/Mike-Casa-della-Pace-circle-group-scaled-e1649237518146-883x1024.jpeg) [ Join us in June! ](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform) Here is the suggested daily timetable for the residency ![](assets/images/Frame-37-1.png) Silent Meditation
+![](/assets/images/Mike-Casa-della-Pace-circle-group-scaled-e1649237518146-883x1024.jpeg) [ Join us in June! ](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform) Here is the suggested daily timetable for the residency ![](/assets/images/Frame-37-1.png) Silent Meditation
 
 7:30 - 8:30
 
-![](assets/images/Group-16.svg) Breakfast Buffet
+![](/assets/images/Group-16.svg) Breakfast Buffet
 
 8:30 - 9:00
 
-![](assets/images/Group-17.svg) emergent dialogue Practice
+![](/assets/images/Group-17.svg) emergent dialogue Practice
 
 9:00 - 10:00
 
-![](assets/images/Group-20.svg) Practical Scenius (cooking, cleaning, gardening, repairs)
+![](/assets/images/Group-20.svg) Practical Scenius (cooking, cleaning, gardening, repairs)
 
 10:00 - 11:00
 
-![](assets/images/Group-19.svg) Work or Leisure, alone or with others
+![](/assets/images/Group-19.svg) Work or Leisure, alone or with others
 
 11:00 - 14:00
 
-![](assets/images/Group-16.svg) Lunch at the table">
+![](/assets/images/Group-16.svg) Lunch at the table">
 
 14:00 - 15:00
 
-![](assets/images/Group-19.svg) Work or Leisure, alone or with others (cooking, cleaning, gardening, repairs)
+![](/assets/images/Group-19.svg) Work or Leisure, alone or with others (cooking, cleaning, gardening, repairs)
 
 15:00 - 18:00
 
-![](assets/images/Frame-37-1.png) Scenius Project or Practical Scenius
+![](/assets/images/Frame-37-1.png) Scenius Project or Practical Scenius
 
 18:00 - 19:00
 
-![](assets/images/Group-17.svg) emergent dialogue Holons
+![](/assets/images/Group-17.svg) emergent dialogue Holons
 
 19:00 - 20:00
 
-![](assets/images/Group-16.svg) Simple Dinner Buffet
+![](/assets/images/Group-16.svg) Simple Dinner Buffet
 
 20:00 - 20:30
 
-![](assets/images/Group-25.svg) Scenius Salons or Free Time until bed
+![](/assets/images/Group-25.svg) Scenius Salons or Free Time until bed
 
 20:30 - ??
 
 ## Facilitators
 
-![](assets/images/Frame-37-2.png)
+![](/assets/images/Frame-37-2.png)
 
 #### Dr. Elizabeth Debold
 
@@ -277,7 +278,7 @@ This inquiry has taken me from feminist activism in New York City to a doctorate
 
 I founded One World in Dialogue, an online forum to explore how intersubjectivity can bring us together across cultures to create new capacities in global consciousness. An author, transformative educator, journalist/editor, community leader and mentor, I have found the answer to my question in the amazing collective emergence of the Co-Conscious We and seek to share its potential in all that I do.
 
-![](assets/images/Thomas-Steininger-300x300-1.jpg)
+![](/assets/images/Thomas-Steininger-300x300-1.jpg)
 
 #### Dr. Thomas Steininger
 
@@ -289,31 +290,31 @@ For the last decades, I have co-founded and developed a process of _emergent dia
 
 ## Testimonials
 
-![](assets/images/1.svg)
+![](/assets/images/1.svg)
 
 Being part of the emergent dialogue practice, experiencing for real a new and deeper way of being together, and also the thrill and excitement of bringing new insights and capacities into existence, is what gives me real hope for a better future for all of us and also the means for how to contribute to that.
 
-–Eirin A., Norway ![](assets/images/Ellipse-1-2.png) ![](assets/images/1.svg)
+–Eirin A., Norway ![](/assets/images/Ellipse-1-2.png) ![](/assets/images/1.svg)
 
 This was one of the most powerful practice gatherings I have experienced.
 
-–Ali W., UK ![](assets/images/Frame-37-2-2.png) ![](assets/images/1.svg)
+–Ali W., UK ![](/assets/images/Frame-37-2-2.png) ![](/assets/images/1.svg)
 
 Opening my life to the We Space has opened my awareness even more to the living field which connects all of existence. In doing so, I feel my Self transformed, along with the way I show up in the relationships in my life. Participating in different We Space programs has given me a great gift of feeling touched, seen and connected effortlessly along with inspiring me to give a voice to this living field, the We Space. It feels easier to ground into the present and receive life’s surprises with grace and clarity.
 
-–Nura, Earth, 30 ![](assets/images/1.svg)
+–Nura, Earth, 30 ![](/assets/images/1.svg)
 
 ...being together on a new level.
 
-–Christo, Witten, Germany ![](assets/images/1.svg)
+–Christo, Witten, Germany ![](/assets/images/1.svg)
 
 I’ve been involved in business start-ups and integral community design for over 40 years… work that was frequently interwoven with my spiritual path. The discovery of we space five years ago was like entering a whole new octave of possibility… in all three arenas. The emergent dialogue work with Elizabeth and Thomas has been particularly beneficial for us since the cultivation of we space has both increased our capacity to work with emergence within the business and to weave a much richer level of connection here in the community.
 
-–Kerry L., Asheville, NC, USA ![](assets/images/Kerry-Lindsey-2-2021-2-1.jpg) ![](assets/images/1.svg)
+–Kerry L., Asheville, NC, USA ![](/assets/images/Kerry-Lindsey-2-2021-2-1.jpg) ![](/assets/images/1.svg)
 
 emergent dialogue is transformation in any community... the practice is Soulfelt.
 
-–Rev. Cass C., USA ![](assets/images/Cass-Charrette.jpg)
+–Rev. Cass C., USA ![](/assets/images/Cass-Charrette.jpg)
 
 ## Part of the Sympoiesis Series
 

--- a/vault/sympoiesis/making-eco-spirituality-accessible-residency-2022.md
+++ b/vault/sympoiesis/making-eco-spirituality-accessible-residency-2022.md
@@ -24,7 +24,7 @@ https://www.youtube.com/watch?v=8Lyvsu2mnUI&t=23s
 - **Notes on costs:** our aim is that cost is not an obstacle to anyone in participating. If finance is an issue please get in touch and we will see if we can provide support in some way or another.
 - **Interested?** [Apply now »](https://docs.google.com/forms/d/e/1FAIpQLSdiykDKyZR6DgtPKeYuNePy9sWc-qkIc4BVfKBRjkFWKvFp-g/viewform)
 
-![](assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
+![](/assets/images/gabriel-jimenez-jin4W1HqgL4-unsplash-scaled-e1637582767309-1024x941.jpg)
 
 ## Overview
 

--- a/vault/upcoming-residencies-gatherings.md
+++ b/vault/upcoming-residencies-gatherings.md
@@ -3,6 +3,7 @@ title: "Upcoming Residencies & Gatherings"
 created: 2022-06-02
 authors: 
   - eilidhross
+image: /assets/images/Blog-Feature-Images-11.png
 ---
 
 @[Life Itself Praxis Hub, Bergerac](https://lifeitself.org/hubs/bergerac/), South of France

--- a/vault/web3.md
+++ b/vault/web3.md
@@ -3,6 +3,7 @@ title: "Web3: Possibilities and Challenges"
 created: 2022-01-26
 authors: 
   - theo-cox
+image: /assets/images/shubham-dhage-gC_aoAjQl2Q-unsplash-scaled.jpg
 ---
 
 ## Making Sense of Crypto & Web3
@@ -15,7 +16,7 @@ authors:
 
 Interest in Web3, initially defined as a ["decentralized online ecosystem based on blockchain"](https://www.wired.com/story/web3-gavin-wood-interview/) and encompassing technologies such as cryptocurrencies, non-fungible tokens (NFTs) and decentralised autonomous organisations (DAOs), is growing massively.
 
-Life Itself has noticed a huge degree of excitement, in parts of our own [highly skeptical](assets/BTC-QF.pdf).
+Life Itself has noticed a huge degree of excitement, in parts of our own [highly skeptical](/assets/BTC-QF.pdf).
 
 The large amounts of information, noise and often fierce divergences of opinion circulating within the Web3 conversation mean it is hard to establish a firm fact of the matter around what potential might exist, in what areas, and what concretely needs to be done in order to help it be realised.
 
@@ -25,7 +26,7 @@ This initiative sees Life Itself bring our own expertise, particularly in the re
 
 We have begun our work by planning a research agenda for our inquiry, shown in the diagram below:
 
-![](assets/images/Screenshot-2022-01-26-160522-1024x726.png)
+![](/assets/images/Screenshot-2022-01-26-160522-1024x726.png)
 
 [https://coggle.it/diagram/YfAKI9b9YjZ5BWx-/t/web3-enquiry-what-done-in-an-efficient%2C-effective-way](https://coggle.it/diagram/YfAKI9b9YjZ5BWx-/t/web3-enquiry-what-done-in-an-efficient%2C-effective-way)
 


### PR DESCRIPTION
Task from #184 

### Summary

This PR replaces pages that had incorrect image paths (ie. image paths in markdown pages did not have required leading slashes) and also adds missing images from frontmatter.

### Changes
* Replace almost all pages with correct links to image paths like `/assets/images/...`
* Add images that were missing
* Fix html typos in page
