### PR TITLE
[vault,site,#184][m]: Add authors and blog layout

### DIFF
--- a/site/content/components/Hero.jsx
+++ b/site/content/components/Hero.jsx
@@ -10,10 +10,10 @@ export default function Hero() {
           <p className="mx-auto mt-3 max-w-md text-lg text-gray-500 sm:text-xl md:mt-5 md:max-w-3xl">We’re committed to practical action for a radically wiser, weller world. We create hubs, do research and engage in advocacy to pioneer a wiser culture.</p>
           <div className="mt-10 sm:flex sm:justify-center lg:justify-start">
             <div className="rounded-md shadow">
-              <a href="/about/" className="flex w-full items-center justify-center rounded-md border border-transparent bg-theme-yellow px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">LEARN MORE</a>
+              <a href="/about/" className="flex w-full items-center justify-center rounded-md border border-transparent bg-secondary px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">LEARN MORE</a>
             </div>
             <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
-              <a href="/upcoming-residencies-gatherings/" className="flex w-full items-center justify-center rounded-md border border-transparent bg-theme-yellow px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">JOIN A RESIDENCY</a>
+              <a href="/upcoming-residencies-gatherings/" className="flex w-full items-center justify-center rounded-md border border-transparent bg-secondary px-8 py-3 text-base font-medium md:py-4 md:px-10 md:text-lg">JOIN A RESIDENCY</a>
             </div>
           </div>
         </div>

--- a/site/content/people
+++ b/site/content/people
@@ -1,0 +1,1 @@
+../../vault/people

--- a/site/contentlayer.config.js
+++ b/site/contentlayer.config.js
@@ -48,13 +48,17 @@ const Page = defineDocumentType(() => ({
   fields: {
     ...sharedFields,
     created: { type: "date" },
+    authors: {
+      type: "list",
+      of: { type: "string" }
+    }
   },
   computedFields,
 }));
 
 const Blog = defineDocumentType(() => ({
   name: "Blog",
-  filePathPattern: `${siteConfig.blogDir}/!(index)*.md*`,
+  filePathPattern: `${siteConfig.blogDir}/**/!(index)*.md*`,
   contentType: "mdx",
   fields: {
     ...sharedFields,
@@ -80,6 +84,7 @@ export const Person = defineDocumentType(() => ({
   contentType: "mdx",
   fields: {
     ...sharedFields,
+    layout: { type: "string", default: "people" },
     id: {
       type: "string",
     },

--- a/site/contentlayer.config.js
+++ b/site/contentlayer.config.js
@@ -70,6 +70,10 @@ const Blog = defineDocumentType(() => ({
       type: "list",
       of: { type: "string" },
     },
+    categories: {
+      type: "list",
+      of: { type: "string" }
+    },
     tags: {
       type: "list",
       of: { type: "string" },

--- a/site/layouts/blog.jsx
+++ b/site/layouts/blog.jsx
@@ -1,35 +1,59 @@
 /* eslint import/no-default-export: off */
 import { formatDate } from "@/lib/formatDate.js";
 import { Avatar } from "@/components/Avatar.jsx";
+import Link from "next/link";
 
 export default function BlogLayout({ children, frontMatter }) {
-  const { title, created, authorsDetails } = frontMatter;
+  const { title, created, image, authorsDetails, categories, tags } = frontMatter;
 
   return (
-    <article className="docs prose prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto p-6">
-      <header>
-        <div className="mb-4 flex-col items-center">
-          {title && <h1 className="flex justify-center">{title}</h1>}
-          {created && (
-            <p className="text-sm text-zinc-400 dark:text-zinc-500 flex justify-center">
-              <time dateTime={created}>{formatDate(created)}</time>
-            </p>
-          )}
-          {authorsDetails && (
-            <div className="flex flex-wrap not-prose items-center space-x-6 space-y-3 justify-center">
-              {authorsDetails.map(({ name, avatar, isDraft, url_path }) => (
-                <Avatar
-                  key={url_path}
-                  name={name}
-                  img={avatar}
-                  href={url_path && !isDraft ? `/${url_path}` : undefined}
-                />
-              ))}
+    <>
+      <Link href="/blog" className="flex flex-col items-center w-fit mx-auto space-x-2 pt-6 text-gray-500 hover:text-gray-900 hover:underline">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 15.75L3 12m0 0l3.75-3.75M3 12h18" />
+        </svg>
+        <p>return to the blog list</p>
+      </Link>
+      <article className="docs prose prose-headings:font-headings dark:prose-invert prose-a:break-words mx-auto max-w-2xl px-6 pt-6">
+        <header className="w-full mx-auto space-y-4 text-center">
+          <div className="flex space-x-4 justify-center border-b border-t border-secondary">
+            {categories ? categories.map((category,i) => (
+              <a key={i} className="py-4 text-xs font-semibold tracking-wider uppercase no-underline hover:underline">#{category}</a>
+            )): <a className="py-4 text-xs font-semibold tracking-wider uppercase no-underline hover:underline">#uncategorized</a>}
+          </div>
+          <div className="mb-4 flex-col items-center">
+            {title && <h1 className="mb-0 text-4xl font-bold leading-tight md:text-5xl">{title}</h1>}
+            <div className="flex items-center justify-center text-sm dark:text-gray-400 space-x-6">
+              <div className="flex items-center space-x-1">
+                {authorsDetails.map(({ name, avatar, isDraft, url_path }) => (
+                  <Avatar
+                    key={url_path}
+                    name={name}
+                    img={avatar}
+                    href={url_path && !isDraft ? `/${url_path}` : undefined}
+                  />
+                ))}
+              </div>
+              <div className="flex items-center space-x-1 mt-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-5 h-5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+                </svg>
+                <time dateTime={created}>{formatDate(created)}</time>
+              </div>
             </div>
-          )}
+          </div>
+          {image && <img src={image} alt={title} className="w-full h-auto m-0 drop-shadow-md" />}
+        </header>
+        <section>{children}</section>
+        <div className="flex items-center space-x-4 py-6 border-b border-theme-yellow text-sm capitalize">{tags &&
+          <>
+            tags:&nbsp;&nbsp;
+            {tags.map((tag,i) => (
+              <a key={i} className="no-underline hover:underline italic">#{tag}</a>
+            ))}
+          </>}
         </div>
-      </header>
-      <section>{children}</section>
-    </article>
+      </article>
+    </>
   );
 }

--- a/site/layouts/people.jsx
+++ b/site/layouts/people.jsx
@@ -1,0 +1,22 @@
+/* eslint import/no-default-export: off */
+export default function PeopleLayout({ children, frontMatter }) {
+  const { name, avatar } = frontMatter;
+
+  return (
+    <article className="prose text-primary dark:text-primary-dark dark:prose-invert prose-headings:font-headings prose-a:break-words w-full mx-auto p-6">
+      <header>
+        <div className="flex items-center space-x-6">
+          {avatar && <div className="w-48">
+            <img className="rounded-lg object-cover shadow-lg" src={avatar} alt={name} />
+          </div>}
+          <div className="flex flex-col">
+            {name && name.split(" ").map(n => (
+              <h1 key={n} className="even:text-primary odd:text-secondary even:text-5xl odd:text-6xl m-0 odd:ml-4">{n}</h1>
+            ))}
+          </div>
+        </div>
+      </header>
+      <section>{children}</section>
+    </article>
+  );
+}

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -19,7 +19,7 @@ module.exports = {
         sans: ["ui-sans-serif", ...defaultTheme.fontFamily.sans],
         serif: ["ui-serif", ...defaultTheme.fontFamily.serif],
         mono: ["ui-monospace", ...defaultTheme.fontFamily.mono],
-        headings: ["-apple-system", ...defaultTheme.fontFamily.sans],
+        headings: ["Archivo", ...defaultTheme.fontFamily.sans],
       },
       colors: {
         background: {
@@ -31,8 +31,8 @@ module.exports = {
           dark: colors.gray[300],
         },
         secondary: {
-          DEFAULT: "",
-          dark: "",
+          DEFAULT: "#F0CA5E",
+          dark: "#F0CA5E",
         },
       },
     },

--- a/vault/people/artearthtech.md
+++ b/vault/people/artearthtech.md
@@ -1,0 +1,4 @@
+---
+id: artearthtech
+name: artearthtech
+---

--- a/vault/people/catherine-tran.md
+++ b/vault/people/catherine-tran.md
@@ -1,0 +1,7 @@
+---
+id: catherine-tran
+name: Catherine Tran
+avatar: /assets/images/Catherine-bio.png
+---
+
+Catherine studied English at the University of Cambridge (UK) before completing a joint M.A. in Cultural Narratives at the University of Guelph (Canada), University of Santiago de Compostela (Spain), and University of Perpignan (France) as an Erasmus Mundus scholar. During her master’s she explored the role that art and literature might play in cultivating ecological responsibility, and she's interested in what it means to be a responsible human being in a web of interspecies interdependence.

--- a/vault/people/charley-lee.md
+++ b/vault/people/charley-lee.md
@@ -1,0 +1,4 @@
+---
+id: charley-lee
+name: Charley Lee
+---

--- a/vault/people/eilidhross.md
+++ b/vault/people/eilidhross.md
@@ -1,0 +1,7 @@
+---
+id: eilidhross
+name: Eilidh Ross
+avatar: /assets/images/IMG_6159-scaled-e1653305020765.jpg
+---
+
+Eilidh studied Law at the University of Oxford before moving back home to Scotland to gain an MSc in Media, Communications and International Journalism from the University of Glasgow. Prior to joining Life Itself, Eilidh has worked as a researcher with the University of Dundee, an assistant editor with Radio Clyde and a Digital Media Officer for the COP26 Coalition. Outside of work, Eilidh enjoys music – from folk, to musical theatre, to country – and can often be found exploring the Scottish countryside with her Great Dane, Selkie

--- a/vault/people/elisalifeitself.md
+++ b/vault/people/elisalifeitself.md
@@ -1,0 +1,4 @@
+---
+id: elisalifeitself
+name: Elisa Paka
+---

--- a/vault/people/iljad20a2d59ebb.md
+++ b/vault/people/iljad20a2d59ebb.md
@@ -1,0 +1,7 @@
+---
+id: iljad20a2d59ebb
+name: Ilja Maiber
+avatar: /assets/images/Ilja-profile-2.jpeg
+---
+
+As Hub manager Ilja makes sure the residents of the Berlin Hub have everything they need to be a living example of a wiser, weller world (and enjoy themselves while they're at it). He combines knowledge in areas such as sustainability and facilitation with a generous curiosity for life.

--- a/vault/people/james-davies-warner.md
+++ b/vault/people/james-davies-warner.md
@@ -1,0 +1,7 @@
+---
+id: james-davies-warner
+name: James Davies-Warner
+avatar: /assets/images/james-headshot-1.jpg
+---
+
+James has had a varied career; ranging across music, education consultancy, property developing, and leek planting. When not drumming, he usually can be found with his nose in a history book or out roaming in his native Suffolk's countryside with Heidi (his dog). Having explored how the initial Anglo-Saxon communities were established in Britain for his MA in Medieval History, he is particularly interested in how communities are formed and remain bonded together (or not as the case may be). He also loves model railways and keeps threatening to build one in the spare bedroom.

--- a/vault/people/jamesredenbaugh.md
+++ b/vault/people/jamesredenbaugh.md
@@ -1,0 +1,4 @@
+---
+id: jamesredenbaugh
+name: James Redenbaugh
+---

--- a/vault/people/joe-hughes.md
+++ b/vault/people/joe-hughes.md
@@ -1,0 +1,4 @@
+---
+id: joe-hughes
+name: Joe Hughes
+---

--- a/vault/people/julie-dayot.md
+++ b/vault/people/julie-dayot.md
@@ -1,0 +1,4 @@
+---
+id: julie-dayot
+name: Julie Dayot
+---

--- a/vault/people/khalil-ali.md
+++ b/vault/people/khalil-ali.md
@@ -1,0 +1,4 @@
+---
+id: khalil-ali
+name: Khalil Ali
+---

--- a/vault/people/liamaet.md
+++ b/vault/people/liamaet.md
@@ -1,0 +1,7 @@
+---
+id: liamaet
+name: Liam Kavanagh
+avatar: /assets/images/liam-Cropped.jpg
+---
+
+Liam Kavanagh is a cognitive scientist who studies how our body and feelings interact with our thoughts, both within the individual and within social groups. Liam studied Economics at Cambridge University, and holds a PhD in Psychology and Cognitive Science from UCSD.

--- a/vault/people/lifexitself.md
+++ b/vault/people/lifexitself.md
@@ -1,0 +1,4 @@
+---
+id: lifexitself
+name: Life Itself
+---

--- a/vault/people/nareshgg7.md
+++ b/vault/people/nareshgg7.md
@@ -1,0 +1,4 @@
+---
+id: nareshgg7
+name: Naresh Giangrande
+---

--- a/vault/people/nathen-fitchen.md
+++ b/vault/people/nathen-fitchen.md
@@ -1,0 +1,7 @@
+---
+id: nathen-fitchen
+name: Nathen Fitchen
+avatar: /assets/images/Untitled-design.png
+---
+
+Nathen Fitchen is a digital marketing expert who works specifically with social enterprises and non-profits creating a better future. He is the co-founder of Wildfeet Productions, a digital media group and is a full-time digital nomad. On his travels he has lived in many communities, co-living spaces and other alternative living situations. He is a trained permaculture designer and has a degree in Earth Sciences from University College London. He loves outdoor adventure sports, cooking, and caring for animals.

--- a/vault/people/petronellac3ecd0923b.md
+++ b/vault/people/petronellac3ecd0923b.md
@@ -1,0 +1,7 @@
+---
+id: petronellac3ecd0923b
+name: Petronella Tyson
+avatar: /assets/images/petronellacopy.jpg.jpg
+---
+
+Petronella has experience in community development, social impact, co-living / working and event planning. She has a love of spreadsheets and making dreams happen.

--- a/vault/people/rufuspollock.md
+++ b/vault/people/rufuspollock.md
@@ -1,0 +1,7 @@
+---
+id: rufuspollock
+name: Rufus Pollock
+avatar: /assets/images/Rufus-Pollock-684x684-1.png
+---
+
+Rufus Pollock is a Founder of Open Knowledge, an award-winning international digital non-profit. Formerly a Shuttleworth Fellow, the Mead Fellow in Economics at Cambridge University.

--- a/vault/people/sen-zhan.md
+++ b/vault/people/sen-zhan.md
@@ -1,0 +1,9 @@
+---
+id: sen-zhan
+name: Sen Zhan
+avatar: /assets/images/Sen-scaled.jpg
+---
+
+Sen is the Hub Spaceship’s Science Officer, unintentional Clown, and occasional General Senghis Zhan. She is committed to lifelong learning, making stuff, and amplifying under-represented voices through podcasting. Sen’s background is in Occupational Therapy, and she brings her transcultural perspective from having lived in China, Canada, and Germany.
+
+Sen is the host and producer of the Beyond Asian Podcast ([www.beyondasian.com](http://www.beyondasian.com)), a series of biographical stories of Third Culture Asian lifelines. Her vision of the future is pillared by conscious co-living, self-examination, and openness to being changed by the currents of Life.

--- a/vault/people/sophie84d503f875.md
+++ b/vault/people/sophie84d503f875.md
@@ -1,0 +1,4 @@
+---
+id: sophie84d503f875
+name: Sophie Kirkham
+---

--- a/vault/people/sylvieshiweibarbier.md
+++ b/vault/people/sylvieshiweibarbier.md
@@ -1,0 +1,7 @@
+---
+id: sylvieshiweibarbier
+name: Sylvie Shiwei Barbier
+avatar: /assets/images/Sylvie-Barbier-800x800-1.jpg
+---
+
+Sylvie Barbier is a French-Taiwanese performance artist, entrepreneur and educator. She co-founded Life Itself to build a wiser future through culture, space and community.

--- a/vault/people/theo-cox.md
+++ b/vault/people/theo-cox.md
@@ -1,0 +1,7 @@
+---
+id: theo-cox
+name: Theo Cox
+avatar: /assets/images/Theo-cropped-1.jpeg
+---
+
+Theo read Politics, Philosophy and Economics at the University of Oxford, and holds an MSc in Development Studies from the London School of Economics. His single greatest drive is to do the most good he can in the world, resulting in his spending probably a bit too much time ruminating on what it means to live a good life. When he’s not philosophising Theo is an avid martial artist, having competed in both western boxing and muay Thai and also regularly training in Brazilian jiujitsu. Despite his love of fighting he remains a committed pacifist in his day to day life, and is just as confused by this seeming contradiction as everyone else.

--- a/vault/people/valerie.md
+++ b/vault/people/valerie.md
@@ -1,0 +1,7 @@
+---
+id: valerie
+name: Valerie Duvauchelle
+avatar: /assets/images/Valerie-profile.jpg
+---
+
+Alongside being a culinary adventurer, a food activist and a tenzo (a zen cook in the Soto Zen tradition), Valerie is the Guardian of Life Itself's daily practices. She enjoys sitting in the uncertainty and is passionate about helping communities to awaken their enthusiastic collective heart through shared practice. She lives life according to her mantra: together, together, all together!


### PR DESCRIPTION
Tasks from #184 

### Summary

This PR migrates authors from lifeitself wordpress to vault and adds layouts for for blogs and authors. It also includes fix to blog's `filePathPattern` in `contentlayer.config.js`

### Changes

* Add authors to people folder in vault
* Modify Blog layout for lifeitself
* Add a people page layout
* Add life itself theme color and heading font
* Contentlayer:
  * fix: glob pattern for blog file path
  * add: default layouts for blog and people
  * add categories field in blog document type

### Screenshots

**Blog Layout** @ [blog/2022/12/20/join-the-first-berlin-hub-residency](https://deploy-preview-252--zesty-liger-3a5c29.netlify.app/blog/2022/12/20/join-the-first-berlin-hub-residency)

<img width="1453" alt="Screen Shot 2022-12-22 at 11 39 10 PM" src="https://user-images.githubusercontent.com/42637597/209213445-8454c02e-c8b9-48fb-87d9-8977d84f60d0.png">

**People Layout** @ [people/nathen-fitchen](https://deploy-preview-252--zesty-liger-3a5c29.netlify.app/people/nathen-fitchen)

<img width="1442" alt="Screen Shot 2022-12-22 at 11 39 37 PM" src="https://user-images.githubusercontent.com/42637597/209213479-c6755489-13a9-496e-8924-b4104ea59229.png">


