### PR TITLE
Add mailchimp newsletter form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .obsidian
 sandbox
 .DS_Store
+*.env

--- a/site/components/Layout.jsx
+++ b/site/components/Layout.jsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
 import { siteConfig } from "../config/siteConfig";
+import NewsletterForm from "./custom/NewsletterForm";
 import { Nav } from "./Nav";
 
 function useTableOfContents(tableOfContents) {
@@ -49,7 +50,8 @@ function useTableOfContents(tableOfContents) {
 }
 
 export function Layout({ children, tableOfContents }) {
-  const { editLink, toc, _raw } = children.props;
+  const { editLink, toc, type: pageType, _raw } = children.props;
+  console.log(children)
   /* if editLink is not set in page frontmatter, link bool value will depend on siteConfig.editLinkShow */
   const editUrl = `${siteConfig.repoRoot}${siteConfig.repoEditPath}${_raw?.sourceFilePath}`;
 
@@ -110,6 +112,7 @@ export function Layout({ children, tableOfContents }) {
             )}
           </main>
         </div>
+        {pageType !== "Podcast" && <NewsletterForm />}
         <footer className="bg-background dark:bg-background-dark prose dark:prose-invert max-w-none flex flex-col items-center justify-center w-full h-auto pt-10 pb-20">
           <div className="flex w-full flex-wrap justify-center">
             {siteConfig.navLinks.map(

--- a/site/components/Layout.jsx
+++ b/site/components/Layout.jsx
@@ -51,7 +51,6 @@ function useTableOfContents(tableOfContents) {
 
 export function Layout({ children, tableOfContents }) {
   const { editLink, toc, type: pageType, _raw } = children.props;
-  console.log(children)
   /* if editLink is not set in page frontmatter, link bool value will depend on siteConfig.editLinkShow */
   const editUrl = `${siteConfig.repoRoot}${siteConfig.repoEditPath}${_raw?.sourceFilePath}`;
 

--- a/site/content/components/NewsletterForm.jsx
+++ b/site/content/components/NewsletterForm.jsx
@@ -24,7 +24,10 @@ export default function NewsletterForm() {
   const onSubmit = (e) => {
     e.preventDefault()
     if (!inputEl.value) return
-    subscribe({ EMAIL: inputEl.value })
+    subscribe({
+      EMAIL: inputEl.value,
+      FNAME: inputEl.value.split("@")[0]
+    })
   }
 
   return (

--- a/site/content/components/NewsletterForm.jsx
+++ b/site/content/components/NewsletterForm.jsx
@@ -1,0 +1,112 @@
+import { useState, useRef, useEffect } from "react";
+import { useMailchimp, Status } from "./useMailchimp";
+
+export default function NewsletterForm() {
+  let inputEl = useRef(null)
+  const [message, setMessage] = useState('')
+  const [subscribed, setSubscribed] = useState(false)
+
+  const url = process.env.NEXT_PUBLIC_MAILCHIMP_URL
+
+  const {subscribe, status, value, error} = useMailchimp(url)
+
+  useEffect(() => {
+    if (status === Status.error) {
+      setMessage('Your e-mail address is invalid or you are already subscribed!')
+    }
+
+    if (status === Status.success && value) {
+      inputEl.value = ''
+      setSubscribed(true)
+    }
+  },[value,status])
+
+  const onSubmit = (e) => {
+    e.preventDefault()
+    if (!inputEl.value) return
+    subscribe({ EMAIL: inputEl.value })
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl py-12 px-6 lg:pt-16 lg:px-8">
+      <div className="rounded-3xl bg-secondary py-10 px-6 sm:py-16 sm:px-12 lg:flex lg:items-center lg:px-20 lg:py-16">
+        <div className="lg:w-0 lg:flex-1 lg:mr-16">
+          <h2 className="text-3xl lg:text-4xl font-bold tracking-tight text-primary font-headings">Stay Connected</h2>
+          <p className="mt-4 max-w-3xl text-md lg:text-lg text-primary">
+            We're actively contributing to a wiser, weller world. If you believe a better world is possible, 
+            our activities will interest you. Join our newsletter to be regularly updated with what's happening at Life Itself.
+          </p>
+          <p className="mt-8 text-md text-primary flex flex-col md:flex-row items-center">
+            <span className="md:mr-4">And check out our socials:</span>
+            <span className="flex space-x-4 mt-4 md:mt-0">
+              {socialIcons.map((el) => (
+                <a key={el.title} href={el.href} target="_blank" className="font-medium text-primary underline">
+                  <svg role="img" viewBox="0 0 24 24" width={18} height={18} xmlns="http://www.w3.org/2000/svg">{el.svgPath}</svg>
+                </a>
+              ))}
+            </span>
+          </p>
+        </div>
+        <div className="mt-12 sm:w-full sm:max-w-md lg:mt-0 lg:ml-16 lg:flex-1">
+          <form className="sm:flex lg:flex-col space-y-8">
+            <label htmlFor="email" className="sr-only">
+              Email address
+            </label>
+            <input
+              id="email-address"
+              name="email"
+              type="email"
+              ref={el => inputEl = el}
+              autoComplete="email"
+              required
+              className="w-full !mt-0 rounded-md border-white px-5 py-3 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-secondary"
+              placeholder={subscribed ? "You're subscribed !  🎉" : 'Enter your email'}
+            />
+            {/* <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups--> */}
+            <div style={{position: "absolute", left: "-5000px"}} aria-hidden="true">
+              <input type="text" name="b_b9efedd3bd8bdfcd2cfbde76d_bec908b5cb" tabIndex="-1" value={''} onChange={() => {}}/>
+            </div>
+            <button
+              onClick={onSubmit}
+              disabled={status === Status.loading || subscribed}
+              className="flex w-full items-center justify-center rounded-md border border-transparent bg-primary disabled:bg-primary/80 px-5 py-3 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-indigo-700 sm:!mt-0 sm:ml-3 lg:!mt-8 lg:!mx-8 sm:w-auto sm:flex-shrink-0"
+            >
+              {status === Status.loading ? 'Subscribing ...' : subscribed ? 'Thank you!' : 'Subscribe'}
+            </button>
+          </form>
+          {error && (
+            <div className="w-72 pt-2 text-sm text-center mx-auto text-primary sm:w-96">{message}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const socialIcons = [
+  { 
+    title: "Twitter",
+    href: "https://twitter.com/forlifeitself",
+    svgPath: <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
+  },
+  { 
+    title: "Instagram",
+    href: "https://www.instagram.com/forlifeitself/",
+    svgPath: <path d="M12 0C8.74 0 8.333.015 7.053.072 5.775.132 4.905.333 4.14.63c-.789.306-1.459.717-2.126 1.384S.935 3.35.63 4.14C.333 4.905.131 5.775.072 7.053.012 8.333 0 8.74 0 12s.015 3.667.072 4.947c.06 1.277.261 2.148.558 2.913.306.788.717 1.459 1.384 2.126.667.666 1.336 1.079 2.126 1.384.766.296 1.636.499 2.913.558C8.333 23.988 8.74 24 12 24s3.667-.015 4.947-.072c1.277-.06 2.148-.262 2.913-.558.788-.306 1.459-.718 2.126-1.384.666-.667 1.079-1.335 1.384-2.126.296-.765.499-1.636.558-2.913.06-1.28.072-1.687.072-4.947s-.015-3.667-.072-4.947c-.06-1.277-.262-2.149-.558-2.913-.306-.789-.718-1.459-1.384-2.126C21.319 1.347 20.651.935 19.86.63c-.765-.297-1.636-.499-2.913-.558C15.667.012 15.26 0 12 0zm0 2.16c3.203 0 3.585.016 4.85.071 1.17.055 1.805.249 2.227.415.562.217.96.477 1.382.896.419.42.679.819.896 1.381.164.422.36 1.057.413 2.227.057 1.266.07 1.646.07 4.85s-.015 3.585-.074 4.85c-.061 1.17-.256 1.805-.421 2.227-.224.562-.479.96-.899 1.382-.419.419-.824.679-1.38.896-.42.164-1.065.36-2.235.413-1.274.057-1.649.07-4.859.07-3.211 0-3.586-.015-4.859-.074-1.171-.061-1.816-.256-2.236-.421-.569-.224-.96-.479-1.379-.899-.421-.419-.69-.824-.9-1.38-.165-.42-.359-1.065-.42-2.235-.045-1.26-.061-1.649-.061-4.844 0-3.196.016-3.586.061-4.861.061-1.17.255-1.814.42-2.234.21-.57.479-.96.9-1.381.419-.419.81-.689 1.379-.898.42-.166 1.051-.361 2.221-.421 1.275-.045 1.65-.06 4.859-.06l.045.03zm0 3.678c-3.405 0-6.162 2.76-6.162 6.162 0 3.405 2.76 6.162 6.162 6.162 3.405 0 6.162-2.76 6.162-6.162 0-3.405-2.76-6.162-6.162-6.162zM12 16c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm7.846-10.405c0 .795-.646 1.44-1.44 1.44-.795 0-1.44-.646-1.44-1.44 0-.794.646-1.439 1.44-1.439.793-.001 1.44.645 1.44 1.439z"/>
+  },
+  { 
+    title: "Whatsapp",
+    href: "#",
+    svgPath: <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
+  },
+  { 
+    title: "Youtube",
+    href: "https://www.youtube.com/@bylifeitself",
+    svgPath: <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+  },
+  { 
+    title: "Github",
+    href: "https://github.com/life-itself",
+    svgPath: <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+  },
+]

--- a/site/content/components/useMailchimp.js
+++ b/site/content/components/useMailchimp.js
@@ -1,0 +1,48 @@
+import { useState, useCallback } from "react";
+import jsonp from "jsonp";
+
+export const Status = {
+	idle: 'IDLE',
+	loading: 'LOADING',
+	success: 'SUCCESS',	
+	error: 'ERROR'
+}
+
+// convert {key: 'value', key2: 'value2'} to 'key=value&key2=value2'
+export function toQueryString(params) {
+  return Object.keys(params)
+    .map((key) => key + "=" + params[key])
+    .join("&");
+}
+
+export function useMailchimp(url) {
+  const [status, setStatus] = useState(Status.idle);
+  const [error, setError] = useState(null);
+  const [value, setValue] = useState(null);
+
+  const subscribe = useCallback((data) => {
+    const params = toQueryString(data);
+    const ajaxURL = url.replace("/post?", "/post-json?");
+    const newUrl = ajaxURL + "&" + params;
+
+    setError(null);
+    setStatus(Status.loading);
+
+    jsonp(newUrl, { param: "c"}, (err, data) => {
+      if (err) {
+        setStatus(Status.error);
+        setError(data.msg);
+      } else if (data.result !== "success") {
+        setStatus(Status.error);
+        setError(data.msg);
+      } else {
+        setStatus(Status.success);
+        setValue(data.msg);
+      }
+    })
+  },[])
+
+  return {
+    subscribe, status, value, error
+  }
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -24,6 +24,7 @@
         "gray-matter": "^4.0.3",
         "hastscript": "^7.0.2",
         "itemsjs": "^2.1.15",
+        "jsonp": "^0.2.1",
         "kbar": "^0.1.0-beta.37",
         "mdx-mermaid": "^2.0.0-rc1",
         "mermaid": "^9.1.4",
@@ -5736,6 +5737,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/katex": {
       "version": "0.13.24",
@@ -14028,6 +14050,29 @@
         "whatwg-url": "^10.0.0",
         "ws": "^8.2.3",
         "xml-name-validator": "^4.0.0"
+      }
+    },
+    "jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "requires": {
+        "debug": "^2.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
       }
     },
     "katex": {

--- a/site/package.json
+++ b/site/package.json
@@ -26,6 +26,7 @@
     "gray-matter": "^4.0.3",
     "hastscript": "^7.0.2",
     "itemsjs": "^2.1.15",
+    "jsonp": "^0.2.1",
     "kbar": "^0.1.0-beta.37",
     "mdx-mermaid": "^2.0.0-rc1",
     "mermaid": "^9.1.4",


### PR DESCRIPTION
Tasks from #307

### Summary

This PR adds lifeitself's mailchimp newsletter signup form in the layout for all pages (except podcast pages).

### Changes
* Create custom components for newsletter - `Newsletter.jsx`, `useMailchimp.js`
  * Add jsonp package (to fetch/post to mailchimp)
* Add Newsletter form component in layout
* Add Mailchimp env variable in Netlify

### Screenshot

<img width="1457" alt="Screen Shot 2023-02-08 at 6 27 32 PM" src="https://user-images.githubusercontent.com/42637597/217577615-cc8559fb-a260-4f93-8797-00ab62053b22.png">
