### PR TITLE
Add posts in author page

### DIFF
--- a/site/content/components/BlogsList.jsx
+++ b/site/content/components/BlogsList.jsx
@@ -1,7 +1,6 @@
+import { useState } from "react";
 import { formatDate } from "@/lib/formatDate.js";
-import { Children, useState } from "react";
-import { useMDXComponent } from "next-contentlayer/hooks";
-import React from "react"
+import { PostBody } from "../../lib/getPageBody.js";
 
 const BLOGS_LOAD_COUNT = 5
 
@@ -9,32 +8,6 @@ const BLOGS_LOAD_COUNT = 5
 //   const body = /^[A-Za-z0-9 ].*/gm.exec(post)
 //   return body[0]
 // }
-
-const strippedComponents = [
-  "h1", "h2", "h3", "h4", "h5", "h6", "li", "img", "ul", "ol", "div", "hr", "pre", "code"
-].reduce((acc,curr)=> (acc[curr]=() => <></>,acc),{})
-
-const PostBody = ({ code }) => {
-  const Component = useMDXComponent(code)
-  const components = {
-    ...strippedComponents,
-    p: (props) => {
-      if (typeof props.children === "string") {
-        return <p className="inline m-0" {...props} />
-      } else {
-        return <></>
-      }
-    },
-    wrapper: ({ children }) => {
-      return <div className="h-20 overflow-hidden line-clamp-3">{
-        children
-      }</div>
-    }
-  }
-  return (
-    <Component components={components} />
-  )
-}
 
 export function BlogsList({ posts }) {
   const [postsCount, setPostsCount] = useState(BLOGS_LOAD_COUNT);

--- a/site/layouts/people.jsx
+++ b/site/layouts/people.jsx
@@ -1,7 +1,23 @@
+import { useState } from "react";
+import { allBlogs } from "contentlayer/generated";
+import { formatDate } from "@/lib/formatDate.js";
+import { PostBody } from "@/lib/getPageBody.js";
+
+const BLOGS_LOAD_COUNT = 6
+
 /* eslint import/no-default-export: off */
 export default function PeopleLayout({ children, frontMatter }) {
-  const { name, avatar } = frontMatter;
+  const { name, avatar, id } = frontMatter;
 
+  const [postsCount, setPostsCount] = useState(BLOGS_LOAD_COUNT);
+
+  const handleLoadMore = () => {
+    setPostsCount((prevCount) => prevCount + BLOGS_LOAD_COUNT);
+  };
+
+  const authorPosts = allBlogs.filter(post => post.authors.includes(id))
+    .sort((a,b) => new Date(b.created) - new Date(a.created))
+  
   return (
     <article className="prose text-primary dark:text-primary-dark dark:prose-invert prose-headings:font-headings prose-a:break-words w-full mx-auto p-6">
       <header>
@@ -17,6 +33,51 @@ export default function PeopleLayout({ children, frontMatter }) {
         </div>
       </header>
       <section>{children}</section>
+      <hr />
+      <div>
+        <h2>Posts by {name}</h2>
+      </div>
+      <ul className="list-none p-0 grid grid-cols-2 gap-4">
+        {authorPosts && authorPosts.slice(0, postsCount).map(post => (
+          <li key={post._id} className="flex flex-col overflow-hidden rounded-lg shadow-lg p-0">
+            <div className="flex-shrink-0 m-0">
+              {post.image && <img className="h-48 w-full object-cover m-0" src={post.image} alt="" />}
+            </div>
+            <div className="flex flex-1 flex-col justify-between bg-white p-6 m-0">
+              <div className="flex-1">
+                <p className="text-sm font-medium text-indigo-600 space-x-2">
+                  {post.categories?.map(category =>
+                    <span key={category} className="underline capitalize">
+                      {category}
+                    </span>
+                  )}
+                </p>
+                <a href={`/${post.url_path}`} className="mt-2 block no-underline">
+                  <p className="text-xl font-semibold font-headings text-gray-900 underline">{post.title}</p>
+                  <PostBody code={post.body.code} frontmatterImage={post.image} />
+                </a>
+              </div>
+              <div className="mt-6 flex items-center">
+                <div className="flex space-x-1 text-sm text-gray-500">
+                  <span aria-hidden="true">&middot;</span>
+                  <time dateTime={post.created}>{formatDate(post.created)}</time>
+                </div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {authorPosts.length > postsCount && (
+        <div className="flex pt-4 w-full">
+          <button
+            onClick={handleLoadMore}
+            type="button"
+            className="inline-flex items-center justify-center rounded bg-secondary mx-auto px-2.5 py-1.5 text-sm font-medium text-primary shadow-sm focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-2"
+          >
+            Show more
+          </button>
+        </div>
+      )}
     </article>
   );
 }

--- a/site/lib/getPageBody.js
+++ b/site/lib/getPageBody.js
@@ -1,0 +1,24 @@
+import { useMDXComponent } from "next-contentlayer/hooks";
+import { Fragment } from "react";
+
+const strippedComponents = [
+  "h1", "h2", "h3", "h4", "h5", "h6", "li", "img", "ul", "ol", "div", "hr", "pre", "code", "embed"
+].reduce((acc,curr)=> (acc[curr]=() => <></>,acc),{})
+
+export const PostBody = ({ code, frontmatterImage }) => {
+  const className = frontmatterImage ? "h-20 line-clamp-3" : "h-64 line-clamp-4"
+  const Component = useMDXComponent(code)
+  const components = {
+    ...strippedComponents,
+    a: (props) => <span {...props} />,
+    p: (props) => <Fragment {...props} />,
+    wrapper: ({ children }) => {
+      return <div className={"overflow-hidden " + className}>
+        {children}
+      </div>
+    }
+  }
+  return (
+    <Component components={components} />
+  )
+}


### PR DESCRIPTION
Task from #260

### Summary

This PR adds the author's posts on the profile page eg. @ `people/{author}`

### Changes
* Modify people layout to include posts from author
* Add custom get page body in lib
* Refactor Bloglist component

### Screenshot author page

[people/nathen-fitchen]()

<img width="1447" alt="Screen Shot" src="https://user-images.githubusercontent.com/42637597/217803752-a13c3baa-cd65-461c-adcc-2862886d8be7.png">
