### PR TITLE
Limit number of posts on blog page

### DIFF
--- a/site/content/getters/blogs.js
+++ b/site/content/getters/blogs.js
@@ -11,5 +11,5 @@ export default function getBlogs() {
       authors: authors.filter(author => post.authors.includes(author['id'])) ?? [siteConfig.author]
     })).sort((a, b) => new Date(b.created) - new Date(a.created))
 
-  return blogs
+  return blogs.slice(0,30)
 }


### PR DESCRIPTION
### Summary

*Deploy builds.*

Data on the blog page exceeds to `>9mb` which may be the cause of netlify builds failing with exit error code. This may be due to netlify limiting page size on it's cdn.

<img width="1135" alt="Screen Shot 2023-03-22 at 10 38 37 PM" src="https://user-images.githubusercontent.com/42637597/227017789-d138f647-e22e-4072-bf21-ab139afdbc75.png">

### Changes
* Slice posts to 30 in `content/getters/blogs.js`