### PR TITLE
Projects [s] - Moved projects page to /projects/index - ref #97

### DIFF
--- a/vault/assets/images/ecosystem-project-image.png
+++ b/vault/assets/images/ecosystem-project-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:424cd0c75d04a5b2d5c005085cb91e28193e11e88af28bc958eac42eb780bba3
+size 213977

--- a/vault/projects/blind-spot-series.md
+++ b/vault/projects/blind-spot-series.md
@@ -1,8 +1,8 @@
 ---
 title: "Blind Spot Series"
-description: "Blind Spots is our new series of conversations exploring the collective blind spots of our society."
-image: /assets/images/Blog-Feature-Images-22.jpg
-homepage:
+description: "Blind Spots is our series of conversations exploring the collective blind spots of our society."
+image: /assets/images/carcrash-scaled.jpg
+homepage: /blind-spots
 start: 2018
 end: 2019
 team:
@@ -18,7 +18,7 @@ created: 2023-03-21
 
 ## Description
 
-Blind Spots is our new series of conversations exploring the collective blind spots of our society.  
+Blind Spots is our series of conversations exploring the collective blind spots of our society.  
   
 What is holding us back from creating a powerful vision for our future? What’s behind the rise in populism? What’s stopping us addressing climate change effectively?
 
@@ -30,5 +30,6 @@ What is holding us back from creating a powerful vision for our future? What’s
 - [[../blog/2019/12/01/blind-spot-3-the-equality-complex |Blind Spot 3: The Equality Complex]]
 - [[../blog/2019/02/06/blind-spots-roberto-unger-future-of-britain |Roberto Unger on the Future of Britain]]
 - [[../blog/2019/10/25/introduction-to-our-collective-blind-spots |Introduction to our Collective Blindspots]]
+
 
 

--- a/vault/projects/collective-wisdom.md
+++ b/vault/projects/collective-wisdom.md
@@ -2,7 +2,7 @@
 title: "Collective Wisdom"
 description: "Western society is deeply attached to ”Enlightenment” ideals of rationality, individualism and equality."
 image: /assets/images/Blog-Feature-Images-7.jpg
-homepage:
+homepage: /collective-wisdom
 start: 2019
 end: 2020
 team:

--- a/vault/projects/ecosystem-mapping.md
+++ b/vault/projects/ecosystem-mapping.md
@@ -1,8 +1,8 @@
 ---
 title: "Polycrisis Response Mapping"
 description: "Charting an emerging ecosystem by Life Itself, Emerge and collaborators. This project maps an emerging ecosystem centred on a radical, alternative approach to social change – one that is simultaneously paradigmatic, integrated and engaged."
-image: /assets/images/Blog-Feature-Images-16.jpg
-homepage:
+image: /assets/images/ecosystem-project-image.png
+homepage: /ecosystem
 start: 2020
 end:
 team:
@@ -26,7 +26,7 @@ This project maps an emerging ecosystem centred on a radical, alternative approa
 
 ## Key Resources
 
-- [Ecosystem Mapping Landing Page & Directory](https://lifeitself.org/ecosystem)
+- [[../ecosystem |Ecosystem Landing Page]]
 - [[../blog/2022/10/25/ecosystem-mapping-update |Ecosystem Mapping Update (October, 2022)]]
 - [[../blog/2022/02/10/mapping-an-emerging-ecosystem-partnership-with-the-institute-for-integral-studies |Ecosystem Mapping Partnership Announcement (February, 2022)]]
 - [[../blog/2021/12/09/mapping-for-emergence |Ecosystem Mapping Collaboration Announcement (December, 2021)]]
@@ -37,6 +37,4 @@ This project maps an emerging ecosystem centred on a radical, alternative approa
 - [[../blog/2021/07/02/richard-d-bartlett |Preliminary Research Interview with Richard D. Bartlett]]
 - [[../blog/2021/06/23/conscious-evolution-robert-cobbold |Preliminary Research Interview with Robert Cobbold]]
 - [[../blog/2021/06/15/joe-lightfoot |Preliminary Research Interview with Joe Lightfoot]]
-
-
 

--- a/vault/projects/exploring-web3-and-crypto.md
+++ b/vault/projects/exploring-web3-and-crypto.md
@@ -2,7 +2,7 @@
 title: "Exploring Web3 & Crypto"
 description: "Crypto & Web3 are a huge phenomenon but can be hard to make sense of. We help with introductions to key concepts and in-depth evaluations of the claims for its social and economic impact."
 image: /assets/images/web3.jpeg
-homepage:
+homepage: https://www.web3.lifeitself.org
 start: 2021-12
 end:
 team:

--- a/vault/projects/hub-bergerac.md
+++ b/vault/projects/hub-bergerac.md
@@ -2,7 +2,7 @@
 title: "Hub - Bergerac"
 description: "The Bergerac Hub offers opportunities to explore what it really means to live more consciously together. The Hub is nestled near the River Dordogne and just a few minutes walk from Bergerac's beautiful town centre. A perfect location from which to enjoy both the glorious French countryside and the vibrant medieval town."
 image: /assets/images/bergerac-hub.jpeg
-homepage:
+homepage: /hubs/bergerac/
 start: 2020
 end: 
 team:

--- a/vault/projects/hub-berlin.md
+++ b/vault/projects/hub-berlin.md
@@ -2,7 +2,7 @@
 title: "The Berlin Hub"
 description: "The Life Itself Berlin Hub in Kreuzberg is an experiment in intentional community living. A place to push for change and grow together through shared values. Our beautiful co-living hub in Berlin has space for new members! If you want to live in a supportive community committed to wellbeing and social change, we'd love to hear from you"
 image: /assets/images/berlin-hub.jpg
-homepage:
+homepage: /hubs/berlin/
 start: 2020
 end: 
 team:

--- a/vault/projects/hub-petit-bois-martin.md
+++ b/vault/projects/hub-petit-bois-martin.md
@@ -2,7 +2,7 @@
 title: "Hub - Petit Bois Martin"
 description: "The Farmhouse is situated in peaceful, natural surroundings just 5 minutes drive from Plum Village Monastery and 20 minutes from the Dordogne River."
 image: /assets/images/qodutNZ.jpg
-homepage:
+homepage: /hubs/farmhouse/
 start: 2020
 end: 
 team:

--- a/vault/projects/hubs.md
+++ b/vault/projects/hubs.md
@@ -2,7 +2,7 @@
 title: "Hubs"
 description: "Our hubs are micro-cultures which embody [the values of Life Itself]. The hubs provide communal environments that support the well-being and self-growth of their residents and foster links with local communities through events, workshops and co-working spaces."
 image: /assets/images/hub-gathering-meal-2019.jpg
-homepage:
+homepage: /hubs
 start: 2020-06-23
 end: 
 team:

--- a/vault/projects/index.md
+++ b/vault/projects/index.md
@@ -1,7 +1,7 @@
 ---
-Title: "Projects"
-Decription: "Life Itself is a multi-level, multi-disciplinary organisation. This page showcases all our projects present and past."
-Created: 2023-03-23
+title: "Our Projects"
+decription: "Life Itself is a multi-level, multi-disciplinary organisation. This page showcases all our projects present and past."
+created: 2023-03-23
 ---
 How do we bring about the shifts in being, culture and systems necessary to transform our social paradigm, and steer humanity and the planet into a flourishing future?
 
@@ -27,31 +27,31 @@ Our work brings inner transformation out of the domain of the purely spiritual, 
 
 ### Active Projects
 
-[[projects/hub-bergerac |The Bergerac Praxis Hub]]
-[[projects/hub-berlin |The Berlin Hub]]
-[[projects/columinate |Columinate]]
-[[projects/conscious-parenting |Conscious Parenting]]
-[[projects/ecosystem-mapping |Ecosystem Mapping]]
-[[projects/exploring-web3-and-crypto |Exploring Web3 & Crypto]]
-[[projects/hubs |Hubs]]
-[[projects/labs |Labs]]
-[[projects/hub-petit-bois-martin |The Petit Bois Martin Hub]]
-[[projects/podcast |The Life Itself Podcast]]
-[[projects/residencies |Residencies]]
-[[projects/tao-of-life-itself |The Tao of Life Itself]]
+- [[projects/hub-bergerac |The Bergerac Praxis Hub]]
+- [[projects/hub-berlin |The Berlin Hub]]
+- [[projects/columinate |Columinate]]
+- [[projects/conscious-parenting |Conscious Parenting]]
+- [[projects/ecosystem-mapping |Ecosystem Mapping]]
+- [[projects/exploring-web3-and-crypto |Exploring Web3 & Crypto]]
+- [[projects/hubs |Hubs]]
+- [[projects/labs |Labs]]
+- [[projects/hub-petit-bois-martin |The Petit Bois Martin Hub]]
+- [[projects/podcast |The Life Itself Podcast]]
+- [[projects/residencies |Residencies]]
+- [[projects/tao-of-life-itself |The Tao of Life Itself]]
 
 
 ### Currently Inactive Projects
 
-[[projects/blind-spot-series |Blind Spots]]
-[[projects/collective-intelligence |Collective Intelligence]]
-[[projects/collective-wisdom |Collective Wisdom]]
-[[projects/contemplative-activism |Contemplative Activism]]
-[[projects/embodying-collective-transformation |Embodying Collective Transformation]]
-[[projects/ontological-politics |Ontological Politics]]
-[[projects/possibility-now |Possibility Now]]
-[[projects/sustainable-wellbeing |Sustainable Wellbeing]]
-[[projects/wisdom-colloquia |Wisdom Colloquia]]
+- [[projects/blind-spot-series |Blind Spots]]
+- [[projects/collective-intelligence |Collective Intelligence]]
+- [[projects/collective-wisdom |Collective Wisdom]]
+- [[projects/contemplative-activism |Contemplative Activism]]
+- [[projects/embodying-collective-transformation |Embodying Collective Transformation]]
+- [[projects/ontological-politics |Ontological Politics]]
+- [[projects/possibility-now |Possibility Now]]
+- [[projects/sustainable-wellbeing |Sustainable Wellbeing]]
+- [[projects/wisdom-colloquia |Wisdom Colloquia]]
 
 
 

--- a/vault/projects/labs.md
+++ b/vault/projects/labs.md
@@ -2,7 +2,7 @@
 title: Life Itself Labs
 description: "Research arm of Life Itself working on systems and data. Strategically relevant because learning and rigor are a key part of our approach."
 image: assets/images/life-itself-labs.png
-homepage:
+homepage: https://labs.lifeitself.org
 start: 2021
 end: 
 team:

--- a/vault/projects/ontological-politics.md
+++ b/vault/projects/ontological-politics.md
@@ -1,8 +1,8 @@
 ---
 title: "Ontological Politics"
 description: "Any social or political envisioning is constrained by an invisible frame**: by the implicit values and views on which it is created, most importantly its view of the nature of human beings."
-image: /assets/images/ontological-politics.jpeg
-homepage:
+image: /assets/images/image_2021-04-16_172851-1024x570.png
+homepage: /ontological-politics
 start: 2020
 end: 
 team:
@@ -27,6 +27,5 @@ If we are to rediscover our political imagination we need to go back to basics. 
 - [[../ontological-politics |Ontological Politics]]
 - [[../blog/2020/10/06/preface-to-an-ontological-politics |A Preface to Ontological Politics]]
 - [Possibility Now]([https://possibilitynow.lifeitself.org](https://possibilitynow.lifeitself.org/)
-
 
 

--- a/vault/projects/podcast.md
+++ b/vault/projects/podcast.md
@@ -2,7 +2,7 @@
 title: "The Life Itself Podcast"
 description: "An ongoing series of conversations with thought leaders in the fields of emerging social change, culture and technology."
 image: /assets/images/projects-life-itself-podcast-header.png
-homepage:
+homepage: /podcast
 start: 2020-11
 end: 
 team:

--- a/vault/projects/possibility-now.md
+++ b/vault/projects/possibility-now.md
@@ -2,7 +2,7 @@
 title: "Possibility Now"
 description: "Possibility Now is an initiative started by Life Itself to spark hope for social change and foster an open-minded, imaginative, collective conversation about how society can be transformed for the better."
 image: /assets/images/Blog-Feature-Images-15.jpg
-homepage:
+homepage: https://possibilitynow.lifeitself.org
 start: 2020
 end: 2020
 team:

--- a/vault/projects/residencies.md
+++ b/vault/projects/residencies.md
@@ -2,7 +2,7 @@
 title: "Residencies"
 description: "A series of residencies and retreats that are a spiritual cooking-together of various ingredients: people, practices, workshops, art, community life and actual cooking."
 image: /assets/images/f30dcd17-9101-4a3a-b8c6-20eea8005010-1024x768.jpeg
-homepage:
+homepage: /upcoming-residencies-gatherings
 start: 2020
 end: 
 team:

--- a/vault/projects/sustainable-wellbeing.md
+++ b/vault/projects/sustainable-wellbeing.md
@@ -2,7 +2,7 @@
 title: "Sustainable Wellbeing"
 description: "Sustainable well-being (SWB) ─ the notion that wellbeing is our top priority and future generations’ wellbeing should be as good or better than ours ─ is an obvious organising principle for our society."
 image: /assets/images/Blog-Feature-Images-6.jpg
-homepage:
+homepage: /sustainable-wellbeing
 start: 2021
 end: 
 team:

--- a/vault/projects/tao-of-life-itself.md
+++ b/vault/projects/tao-of-life-itself.md
@@ -2,7 +2,7 @@
 title: "Tao of Life Itself"
 description: "A guide to our way of being and doing. A combination of our playbook and our concrete envisioning of how pioneering Life Itself aligned communities operate."
 image: /assets/images/jose-luis-sanchez-pereyra-U6HOr6-CPSA-unsplash-scaled.jpg
-homepage:
+homepage: https://lifeitself.org/tao
 start: 2016
 end:
 team:


### PR DESCRIPTION
Preview of the page: https://deploy-preview-397--zesty-liger-3a5c29.netlify.app/projects 

Project page is now fixed and showing up correctly. Currently separated only by active and inactive and in chronological order. 

- I've also made small changes to the projects pages. @rufuspollock **I am not 100% sure if the way I have added the front matter for homepage is correct**
- Both the Berlin hub page and Petit Bois page do not seem to be able to be linked: in Obsidian when I create the link (e.g. [[hubs/berlin |Berlin Hub Page]] this remains greyed out and does not link. Why is this and how can I fix it? 
- Wisdom Colloquia currently has no information and there is no landing page or information about it
