### PR TITLE
Homepage v3 writing and initiative sections

### DIFF
--- a/site/content/components/InitiativeCard.jsx
+++ b/site/content/components/InitiativeCard.jsx
@@ -1,0 +1,19 @@
+export default function InitiativeCard({ initiative }) {
+  return (
+    <li className="group relative flex flex-col items-start">
+      <h2 className="mt-6 text-base font-semibold text-zinc-800 dark:text-zinc-100">
+        <div className="absolute -inset-x-4 -inset-y-6 z-0 scale-95 bg-zinc-100 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 dark:bg-zinc-800/50 sm:-inset-x-6 sm:rounded-2xl"></div>
+        <a href={initiative.url_path} className="flex transition font-medium text-primary group-hover:text-secondary">
+          <span className="absolute -inset-x-4 -inset-y-6 z-20 sm:-inset-x-6 sm:rounded-2xl" />
+          <svg viewBox="0 0 24 24" aria-hidden="true" className="z-10 h-6 w-6 flex-none">
+            <path fill="currentColor" d="M15.712 11.823a.75.75 0 1 0 1.06 1.06l-1.06-1.06Zm-4.95 1.768a.75.75 0 0 0 1.06-1.06l-1.06 1.06Zm-2.475-1.414a.75.75 0 1 0-1.06-1.06l1.06 1.06Zm4.95-1.768a.75.75 0 1 0-1.06 1.06l1.06-1.06Zm3.359.53-.884.884 1.06 1.06.885-.883-1.061-1.06Zm-4.95-2.12 1.414-1.415L12 6.344l-1.415 1.413 1.061 1.061Zm0 3.535a2.5 2.5 0 0 1 0-3.536l-1.06-1.06a4 4 0 0 0 0 5.656l1.06-1.06Zm4.95-4.95a2.5 2.5 0 0 1 0 3.535L17.656 12a4 4 0 0 0 0-5.657l-1.06 1.06Zm1.06-1.06a4 4 0 0 0-5.656 0l1.06 1.06a2.5 2.5 0 0 1 3.536 0l1.06-1.06Zm-7.07 7.07.176.177 1.06-1.06-.176-.177-1.06 1.06Zm-3.183-.353.884-.884-1.06-1.06-.884.883 1.06 1.06Zm4.95 2.121-1.414 1.414 1.06 1.06 1.415-1.413-1.06-1.061Zm0-3.536a2.5 2.5 0 0 1 0 3.536l1.06 1.06a4 4 0 0 0 0-5.656l-1.06 1.06Zm-4.95 4.95a2.5 2.5 0 0 1 0-3.535L6.344 12a4 4 0 0 0 0 5.656l1.06-1.06Zm-1.06 1.06a4 4 0 0 0 5.657 0l-1.061-1.06a2.5 2.5 0 0 1-3.535 0l-1.061 1.06Zm7.07-7.07-.176-.177-1.06 1.06.176.178 1.06-1.061Z"></path>
+          </svg>
+          <span className="relative z-10">{initiative.title}</span>
+        </a>
+      </h2>
+      <p className="relative z-10 mt-2 text-sm text-zinc-600 line-clamp-3">
+        {initiative.description}
+      </p>
+    </li>
+  )
+}

--- a/site/content/getters/blogs.js
+++ b/site/content/getters/blogs.js
@@ -2,7 +2,7 @@ import { allBlogs, allDocuments } from 'contentlayer/generated';
 import { siteConfig } from '../../config/siteConfig';
 import { parseMarkdown } from '@/lib/parseMarkdown';
 
-export default function getBlogs() {
+export default function getBlogs(slicedPosts = 30) {
   const authors = allDocuments.filter(doc => doc.type === "Person")
   const blogs = allBlogs.filter(post => !post.isDraft)
     .map(post => ({
@@ -11,5 +11,5 @@ export default function getBlogs() {
       authors: authors.filter(author => post.authors.includes(author['id'])) ?? [siteConfig.author]
     })).sort((a, b) => new Date(b.created) - new Date(a.created))
 
-  return blogs.slice(0,30)
+  return blogs.slice(0,slicedPosts)
 }

--- a/site/content/initiatives
+++ b/site/content/initiatives
@@ -1,0 +1,1 @@
+../../vault/initiatives/

--- a/site/content/initiatives.md
+++ b/site/content/initiatives.md
@@ -1,1 +1,0 @@
-../../vault/initiatives.md

--- a/site/content/projects
+++ b/site/content/projects
@@ -1,1 +1,0 @@
-../../vault/projects

--- a/site/contentlayer.config.js
+++ b/site/contentlayer.config.js
@@ -15,6 +15,7 @@ import wikiLinkPlugin from "remark-wiki-link-plus";
 import mdxMermaid from 'mdx-mermaid';
 
 import { siteConfig } from "./config/siteConfig";
+import { formatDate } from "./lib/formatDate"
 
 const sharedFields = {
   title: { type: "string" },
@@ -131,6 +132,41 @@ const Podcast = defineDocumentType(() => ({
   computedFields
 }))
 
+const resolutionOptions = [
+  "incubating",
+  "active",
+  "dormant",
+  "completed",
+  "retired",
+  "merged",
+  "cancelled"
+]
+
+const Initiative = defineDocumentType(() => ({
+  name: "Initiative",
+  contentType: "mdx",
+  filePathPattern: "initiatives/**/*.md*",
+  fields: {
+    ...sharedFields,
+    homepage: { type: "json" },
+    start: { type: "json" },
+    end: { type: "json" },
+    team: { type: "list", of: { type: "string" }, default: [] },
+    size: { type: "enum", options: ["xl", "l", "m", "s", "xs"] },
+    state: { type: "enum", options: ["open", "closed"] },
+    status: { type: "enum", options: resolutionOptions },
+    resolution: { type: "enum", options: resolutionOptions },
+    created: { type: "date" },
+  },
+  computedFields: {
+    ...computedFields,
+    alumni: {
+      type: "list",
+      resolve: doc => doc.alumni ?? []
+    }
+  }
+}))
+
 /* Ecosystem document types */
 
 const NestedUrl = defineNestedType(() => ({
@@ -232,7 +268,7 @@ export default makeSource({
     ...siteConfig.contentExclude,
   ]),
   contentDirInclude: siteConfig.contentInclude,
-  documentTypes: [Blog, Person, Podcast, Profile, Topic, Page],
+  documentTypes: [Blog, Person, Podcast, Profile, Topic, Initiative, Page],
   mdx: {
     cwd: process.cwd(),
     remarkPlugins: [

--- a/site/pages/home-new.jsx
+++ b/site/pages/home-new.jsx
@@ -1,0 +1,304 @@
+
+import { allBlogs, allInitiatives } from "contentlayer/generated"
+import getBlogs from "../content/getters/blogs"
+
+import Collaborators from "components/custom/collaborators.jsx"
+import BlogSlider from "components/custom/BlogSlider.jsx"
+import InitiativeCard from "components/custom/InitiativeCard"
+
+import { formatDate } from "@/lib/formatDate"
+
+const keyWritingsPaths = [
+  "blog/2022/02/01/cultivating-an-emerging-paradigm"
+]
+
+const keyInitiativesPaths = [
+  // "initiatives/blind-spot-series",
+]
+
+const keyWritingsData = [
+  {
+    id: 1,
+    title: 'Cultivating An Emerging Paradigm',
+    href: '/blog/2022/02/01/cultivating-an-emerging-paradigm',
+    description: 'Humanity and the planet are at a critical point in history similar to major breakdown/breakthrough points of the past, most recently the transition to modernity in the Enlightenment. We risk civilizational collapse and we also have the possibility of a breakthrough. How do we facilitate the latter?',
+    imageUrl: '/assets/images/Blog-Feature-Images-7.png',
+    date: 'Mar 16, 2020',
+    datetime: '2020-03-16',
+    category: { title: 'Vision', href: '#' },
+    author: {
+      name: 'Michael Foster',
+      role: 'Co-Founder / CTO',
+      href: '#',
+      imageUrl:
+        'https://images.unsplash.com/photo-1519244703995-f4e0f30006d5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+  },
+  // More posts...
+]
+
+const keyInitiativesData = [
+  {
+    id: 1,
+    title: 'Cultivating An Emerging Paradigm',
+    href: '/blog/2022/02/01/cultivating-an-emerging-paradigm',
+    description: 'Humanity and the planet are at a critical point in history similar to major breakdown/breakthrough points of the past, most recently the transition to modernity in the Enlightenment. We risk civilizational collapse and we also have the possibility of a breakthrough. How do we facilitate the latter?',
+    imageUrl: '/assets/images/Blog-Feature-Images-7.png',
+  },
+  // More ...
+]
+
+export default function Home({ posts, keyWritings, keyInitiatives }) {
+  console.log(keyInitiatives)
+  return (
+  <>
+  <section className="lg:relative">
+    <div className="font-archivo mx-auto w-full max-w-7xl pt-16 pb-20 text-center lg:pt-48 lg:text-left">
+      <div className="px-4 sm:px-8 lg:w-1/2 xl:pr-16">
+        <h1 className="text-2xl font-headings font-bold tracking-tight text-primary xl:text-4xl flex flex-col">
+          Ever asked yourself ... How can I live a happier life? Create a better society?
+        </h1>
+        <p className="mx-auto mt-3 max-w-md text-base text-gray-500 sm:text-base md:mt-5 md:max-w-3xl">
+          We’re an open community dedicated to the art of wiser living and social transformation. We favor approaches that prioritize inner development and cultural change in a rigorous, practical way.
+          <br/><br/>
+          Sign up to our monthly newsletter for latest updates, projects and community news.
+        </p>
+        <div className="mt-10 sm:mt-12">
+          <form action="#" className="sm:mx-auto sm:max-w-xl lg:mx-0">
+            <div className="sm:flex">
+              <div className="min-w-0 flex-1">
+                <label htmlFor="email" className="sr-only">
+                  Email address
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  placeholder="Enter your email"
+                  className="block w-full rounded-md border-0 px-4 py-3 text-base text-primary placeholder-gray-500 ring-1 ring-primary focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div className="mt-3 sm:ml-3 sm:mt-0">
+                <button
+                  type="submit"
+                  className="block w-full rounded-md bg-secondary px-4 py-3 font-medium text-primary shadow focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  Sign Up
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <div className="relative h-64 w-full sm:h-72 md:h-96 lg:absolute lg:inset-y-0 lg:right-0 lg:w-1/2 lg:h-full">
+      <img className="absolute inset-0 mx-auto h-full object-fit" src="/assets/lifeitself-landingpage.webp" alt="" />
+    </div>
+  </section>
+
+  <Collaborators />
+
+  <BlogSlider posts={posts} />
+
+  <section>
+    <div className="bg-white px-6 py-24 sm:py-32 lg:px-8">
+      <div className="mx-auto max-w-2xl text-center">
+        <h2 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">What We're About</h2>
+        <div className="mt-6 text-xl leading-8 text-gray-600 space-y-6">
+          <p>
+            In the past four decades, a confirmation and expansion of wisdom traditions by scientific rigor has converged with an ever deepening polycrisis.
+          </p>
+          <p>
+            There has never been a more important time to “grow up”, both personally and collectively. A paradigm shift is underway and we all have a part to play.
+          </p>
+          <p>
+            The big question is ... how?
+          </p>
+          <p>
+            Life itself is a home for people who are dedicated to rigorous enquiry and deliberate action for inner growth and cultural evolution in the service of social transformation -- creating an awakening society and a radically wiser, weller world.
+          </p>
+          <p>
+            Inspired by integral theory, zen buddhism and other key concepts, we cultivate these ideas and apply them to life itself, through deliberately developmental programs and community building.
+          </p>
+          <p>
+            <a
+              href="/about"
+              className="rounded-md bg-white px-3.5 py-2.5 font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              Learn More
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div className="bg-gray-900 py-24 sm:py-32">
+      <div className="relative isolate">
+        <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+          <div className="mx-auto flex max-w-2xl flex-col gap-16 bg-white/5 px-6 py-16 ring-1 ring-white/10 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:flex-row lg:items-center lg:py-20 xl:gap-x-20 xl:px-20">
+            <img
+              className="h-96 w-full flex-none rounded-2xl object-cover shadow-xl lg:aspect-square lg:h-auto lg:max-w-sm"
+              src="https://images.unsplash.com/photo-1519338381761-c7523edc1f46?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=800&q=80"
+              alt=""
+            />
+            <div className="w-full flex-auto">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Join The Community</h2>
+              <p className="mt-6 text-lg leading-8 text-gray-300">
+                Our community chat is bustling, come in and say hey! 
+
+                This is a space for you if:
+                - You want to connect with like-minded people interested in creating a wiser, weller world
+                - You want to learn from and meet experts in different fields from psychology, education, technology, metamodern philosophy and more
+                - You want to build your professional network with other professionals
+
+                We meet online on a bi-monthly basis for deep discussions and communal gathering.
+              </p>
+              <div className="mt-10 flex">
+                <a href="https://chat.whatsapp.com/JNJCTZugNQn1fq89xbHtfA" className="text-sm font-semibold leading-6 text-indigo-400">
+                  Join Here <span aria-hidden="true">&rarr;</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="absolute inset-x-0 -top-16 -z-10 flex transform-gpu justify-center overflow-hidden blur-3xl">
+          <svg viewBox="0 0 1318 752" className="w-[82.375rem] flex-none" aria-hidden="true">
+            <path
+              fill="url(#ee394704-5802-4a27-9451-3d29bf7415a3)"
+              fillOpacity=".25"
+              d="m279.655 479.549-211.511-96.46L.638 751.469l279.017-271.92 380.928 173.723c-77.415-137.198-159.845-384.186 129.758-274.555C1152.34 515.756 1226.88 775.51 1299.76 547.101c58.31-182.726-41.07-382.222-98.04-459.13L964.951 386.243 771.295.416 279.655 479.55Z"
+            />
+            <defs>
+              <linearGradient
+                id="ee394704-5802-4a27-9451-3d29bf7415a3"
+                x1="1452.56"
+                x2="-101.59"
+                y1="515.446"
+                y2="760.592"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stopColor="#4F46E5" />
+                <stop offset={1} stopColor="#80CAFF" />
+              </linearGradient>
+            </defs>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div className="bg-white py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Key Writings</h2>
+          <p className="mt-2 text-lg leading-8 text-gray-600">
+            Read some of our most essential pieces.
+          </p>
+        </div>
+        <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+          {keyWritings?.map((post) => (
+            <article key={post._id} className="flex flex-col items-start justify-between">
+              <div className="relative w-full">
+                <img
+                  src={post.image}
+                  alt={post.title}
+                  className="aspect-[16/9] w-full rounded-2xl bg-gray-100 object-cover sm:aspect-[2/1] lg:aspect-[3/2]"
+                />
+                <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-gray-900/10" />
+              </div>
+              <div className="max-w-xl">
+                <div className="mt-8 flex items-center gap-x-4 text-xs">
+                  <time dateTime={post.created} className="text-gray-500">
+                    {formatDate(post.date ?? post.created)}
+                  </time>
+                  {post.categories?.map((category,index) => (
+                    <a
+                      key={`${category}-${index}`}
+                      href={`/categories/${category}`}
+                      className="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600 hover:bg-gray-100"
+                    >
+                      {category}
+                    </a>
+                  ))}
+                </div>
+                <div className="group relative">
+                  <h3 className="mt-3 text-lg font-semibold leading-6 text-primary group-hover:text-gray-600">
+                    <a href={post.url_path}>
+                      <span className="absolute inset-0" />
+                      {post.title}
+                    </a>
+                  </h3>
+                  <p className="mt-5 line-clamp-3 text-sm leading-6 text-gray-600">{post.description}</p>
+                </div>
+                <div className="relative mt-8 flex items-center gap-x-4">
+                  <img src={post.authors[0]?.avatar} alt="" className="h-10 w-10 rounded-full bg-gray-100" />
+                  <div className="text-sm leading-6">
+                    <p className="font-semibold text-gray-900">
+                      <a href={post.authors[0]?.url_path}>
+                        <span className="absolute inset-0" />
+                        {post.authors[0]?.name}
+                      </a>
+                    </p>
+                    <p className="text-gray-600">{post.author?.role}</p>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div className="bg-white py-24 sm:py-32">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Key Initiatives</h2>
+          <p className="mt-2 text-lg leading-8 text-gray-600">
+            Read about of our major initiatives.
+          </p>
+        </div>
+        <ul role="list" className="mx-auto mt-16 grid max-w-2xl grid-cols-1 sm:grid-cols-2 gap-x-12 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+          {keyInitiatives?.map((initiative) => (
+            <InitiativeCard key={initiative._id} initiative={initiative} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+  </>
+  )
+}
+
+export async function getStaticProps() {
+  const posts = await getBlogs(9)
+  const keyWritings = await getBlogs(allBlogs.length)
+    .filter(post => keyWritingsPaths?.includes(post.url_path))
+
+  const keyInitiatives = keyInitiativesPaths.length > 0 
+    ? allInitiatives
+      .filter(
+        initiative => keyInitiativesPaths?.includes(initiative.url_path)
+      ) 
+    : allInitiatives.filter(initiative => !(initiative.url_path === "initiatives"))
+        .sort((a,b) => new Date(b.created) - new Date(a.created))
+        .slice(0,6)
+  /*
+  const keyWritingsNew = [
+    getBlogPostInfoByPath(...),
+    getBlogPostInfoByPath(...),
+    getBlogPostInfoByPath(...),
+  ]
+
+  const keyInitiatives = [
+    getInitiativeBySlug('...')
+  ]
+  */
+
+  return {
+    props: { posts, keyWritings, keyInitiatives }
+  }
+}


### PR DESCRIPTION
Tasks from #335 

### Summary

This PR adds a modified version of the homepage at /home-new with fixes to hero and new sections for key writings and key initiatives.

### Changes

* Fixes to Hero section styles
* Add / fix symlinks in `site/content` after projects renamed to initiatives
* Add `InitiativeCard.jsx` in components
* homepage v3 at `pages/home-new.jsx`
* Key writings section
  * modified `content/getters/blogs.js` to be reusable
  * posts are filtered by `keyWritingsPaths` array which is a `string[ ]` of blog paths
* Key Initiatives section
  * add initiative document type with fields in `contentlayer.config.js`
  * initiatives are filtered by `keyInitiativesPaths` array - `string[ ] of initiative paths`

### Previews

- Key Initiatives

<img width="1444" alt="Screen Shot 2023-03-30" src="https://user-images.githubusercontent.com/42637597/228956583-f50e8ebd-69b4-4851-8e8b-44908f75e7d7.png">

