### PR TITLE
Fix in-markdown links

### DIFF
--- a/content/blog/2018/03/02/remythologizing-technology.md
+++ b/content/blog/2018/03/02/remythologizing-technology.md
@@ -45,6 +45,6 @@ Maybe it is time to re-mythologize human nature to one that is good, kind and lo
 
 ### _More from Sylvie Shiwei Barbier_
 
-https://lifeitself.org/2017/09/26/the-state-reinvented/
+https://lifeitself.org/2017/09/26/the-state-reinvented
 
-https://lifeitself.org/2022/05/03/art-religion-and-the-climate-crisis/
+https://lifeitself.org/2022/05/03/art-religion-and-the-climate-crisis

--- a/content/blog/2018/05/01/mcgilchrist-master-and-his-emissary-notes.md
+++ b/content/blog/2018/05/01/mcgilchrist-master-and-his-emissary-notes.md
@@ -651,6 +651,6 @@ The irony here is i generally agree with McGilchrist but I find the evidence pre
 
 #### _More from Life Itself_
 
-https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science/
+https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science
 
-https://lifeitself.org/2022/06/09/launch-announcement-life-itself-labs/
+https://lifeitself.org/2022/06/09/launch-announcement-life-itself-labs

--- a/content/blog/2018/06/08/can-digital-businesses-thrive-and-be-mindful.md
+++ b/content/blog/2018/06/08/can-digital-businesses-thrive-and-be-mindful.md
@@ -154,8 +154,8 @@ _Excerpt From: Thich Nhat Hanh. “The Art of Power” Chapter Four_
 
 #### _More from Life Itself_
 
-https://lifeitself.org/2022/03/16/making-sense-of-crypto-and-web3-launch/
+https://lifeitself.org/2022/03/16/making-sense-of-crypto-and-web3-launch
 
-https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism/
+https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism
 
-https://lifeitself.org/2022/02/01/a-teacher-of-eternity-a-lasting-afternoon-with-thich-nhat-hanh/
+https://lifeitself.org/2022/02/01/a-teacher-of-eternity-a-lasting-afternoon-with-thich-nhat-hanh

--- a/content/blog/2019/01/22/ken-wilber-integral-spirituality.md
+++ b/content/blog/2019/01/22/ken-wilber-integral-spirituality.md
@@ -129,8 +129,8 @@ More intellectually (i.e. of less immediate practical importance)
 
 * * *
 
-https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism/
+https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism
 
-https://lifeitself.org/2022/02/10/mapping-an-emerging-ecosystem-partnership-with-the-institute-for-integral-studies/
+https://lifeitself.org/2022/02/10/mapping-an-emerging-ecosystem-partnership-with-the-institute-for-integral-studies
 
-https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science/
+https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science

--- a/content/blog/2019/02/04/darwins-cathedral-david-sloan-wilson.md
+++ b/content/blog/2019/02/04/darwins-cathedral-david-sloan-wilson.md
@@ -283,6 +283,6 @@ When Elliott Sober and I wanted to say something general about group selection a
 
 * * *
 
-https://lifeitself.org/2022/05/03/art-religion-and-the-climate-crisis/
+https://lifeitself.org/2022/05/03/art-religion-and-the-climate-crisis
 
-https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism/
+https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism

--- a/content/blog/2019/02/20/we-have-failed-to-escape-mystery.md
+++ b/content/blog/2019/02/20/we-have-failed-to-escape-mystery.md
@@ -44,6 +44,6 @@ These hopes to escape mystery have failed, and various strands of science lead u
 
 * * *
 
-https://lifeitself.org/2022/02/01/cultivating-an-emerging-paradigm/
+https://lifeitself.org/2022/02/01/cultivating-an-emerging-paradigm
 
-https://lifeitself.org/2022/02/01/a-teacher-of-eternity-a-lasting-afternoon-with-thich-nhat-hanh/
+https://lifeitself.org/2022/02/01/a-teacher-of-eternity-a-lasting-afternoon-with-thich-nhat-hanh

--- a/content/blog/2019/04/10/ritual-and-the-return-to-mystery.md
+++ b/content/blog/2019/04/10/ritual-and-the-return-to-mystery.md
@@ -57,6 +57,6 @@ So mindfulness meditation can be approached as a ritual, but it is not the only 
 
 * * *
 
-https://lifeitself.org/2019/02/20/we-have-failed-to-escape-mystery/
+https://lifeitself.org/2019/02/20/we-have-failed-to-escape-mystery
 
-https://lifeitself.org/2018/03/02/remythologizing-technology/
+https://lifeitself.org/2018/03/02/remythologizing-technology

--- a/content/blog/2019/11/04/blind-spot-1-faith-in-rationality-and-progress.md
+++ b/content/blog/2019/11/04/blind-spot-1-faith-in-rationality-and-progress.md
@@ -48,8 +48,8 @@ _[Blind Spots](https://artearthtech.com/institute/blind-spots/) is our new seri
 
 * * *
 
-https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land/
+https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land
 
-https://lifeitself.org/2022/04/30/self-burning-confronts-us-with-radical-concern-if-we-let-it/
+https://lifeitself.org/2022/04/30/self-burning-confronts-us-with-radical-concern-if-we-let-it
 
-https://lifeitself.org/2022/04/25/reflections-on-the-making-eco-spirituality-accessible-residency/
+https://lifeitself.org/2022/04/25/reflections-on-the-making-eco-spirituality-accessible-residency

--- a/content/blog/2019/11/18/blind-spot-2-individualism.md
+++ b/content/blog/2019/11/18/blind-spot-2-individualism.md
@@ -34,6 +34,6 @@ Please also check the previous blind spot events we organized [Blind Spots #1: 
 
 * * *
 
-https://lifeitself.org/2019/10/25/introduction-to-our-collective-blind-spots/
+https://lifeitself.org/2019/10/25/introduction-to-our-collective-blind-spots
 
-https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress/
+https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress

--- a/content/blog/2019/11/29/the-case-for-contemplative-activism-why-why-now-and-what-are-we-offering.md
+++ b/content/blog/2019/11/29/the-case-for-contemplative-activism-why-why-now-and-what-are-we-offering.md
@@ -118,8 +118,8 @@ _Liam Kavanagh_
 
 * * *
 
-https://lifeitself.org/2019/11/18/blind-spot-2-individualism/
+https://lifeitself.org/2019/11/18/blind-spot-2-individualism
 
-https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land/
+https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land
 
-https://lifeitself.org/2017/05/31/the-way-we-live-now/
+https://lifeitself.org/2017/05/31/the-way-we-live-now

--- a/content/blog/2019/12/01/blind-spot-3-the-equality-complex.md
+++ b/content/blog/2019/12/01/blind-spot-3-the-equality-complex.md
@@ -67,6 +67,6 @@ On Sunday 12th July, Dr Liam Kavanagh will be leading a discussion on this topic
 
 * * *
 
-https://lifeitself.org/2019/11/18/blind-spot-2-individualism/
+https://lifeitself.org/2019/11/18/blind-spot-2-individualism
 
-https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress/
+https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress

--- a/content/blog/2020/06/13/contemplating-denial.md
+++ b/content/blog/2020/06/13/contemplating-denial.md
@@ -56,8 +56,8 @@ Ah well. Change, denial, self, non duality, consciousness… all of these concep
 
 * * *
 
-https://lifeitself.org/2020/06/11/contemplative-activism-a-primer/
+https://lifeitself.org/2020/06/11/contemplative-activism-a-primer
 
-https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress/
+https://lifeitself.org/2019/11/04/blind-spot-1-faith-in-rationality-and-progress
 
-https://lifeitself.org/2019/11/18/blind-spot-2-individualism/
+https://lifeitself.org/2019/11/18/blind-spot-2-individualism

--- a/content/blog/2020/12/19/word-laundrette-1-nirvana.md
+++ b/content/blog/2020/12/19/word-laundrette-1-nirvana.md
@@ -43,8 +43,8 @@ _Much of the text here appears in my forthcoming book, “Collective Wisdom in t
 
 * * *
 
-https://lifeitself.org/2016/10/23/my-introduction-to-gautamas-uncommon-wisdom/
+https://lifeitself.org/2016/10/23/my-introduction-to-gautamas-uncommon-wisdom
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality
 
-https://lifeitself.org/2020/05/12/qi-gong-the-eight-precious-exercises/
+https://lifeitself.org/2020/05/12/qi-gong-the-eight-precious-exercises

--- a/content/blog/2021/04/15/reinventing-organisations-by-frederic-laloux.md
+++ b/content/blog/2021/04/15/reinventing-organisations-by-frederic-laloux.md
@@ -500,6 +500,6 @@ From the Notes
 
 * * *
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality
 
-https://lifeitself.org/2019/02/04/darwins-cathedral-david-sloan-wilson/
+https://lifeitself.org/2019/02/04/darwins-cathedral-david-sloan-wilson

--- a/content/blog/2021/04/30/views-and-abolition.md
+++ b/content/blog/2021/04/30/views-and-abolition.md
@@ -18,6 +18,6 @@ _You can download the full essay over on our [Community Projects](https://lifeit
 
 * * *
 
-https://lifeitself.org/2020/06/11/contemplative-activism-a-primer/
+https://lifeitself.org/2020/06/11/contemplative-activism-a-primer
 
-https://lifeitself.org/2017/04/20/logic-of-our-purpose-and-reason-for-our-existence-scqh/
+https://lifeitself.org/2017/04/20/logic-of-our-purpose-and-reason-for-our-existence-scqh

--- a/content/blog/2021/05/14/notes-on-creating-a-life-together-by-diana-leafe-christian.md
+++ b/content/blog/2021/05/14/notes-on-creating-a-life-together-by-diana-leafe-christian.md
@@ -567,8 +567,8 @@ Great examples on joining processes.
 
 * * *
 
-https://lifeitself.org/2021/04/15/reinventing-organisations-by-frederic-laloux/
+https://lifeitself.org/2021/04/15/reinventing-organisations-by-frederic-laloux
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality
 
-https://lifeitself.org/2017/06/06/examining-what-do-we-want/
+https://lifeitself.org/2017/06/06/examining-what-do-we-want

--- a/content/blog/2021/06/15/joe-lightfoot.md
+++ b/content/blog/2021/06/15/joe-lightfoot.md
@@ -44,4 +44,4 @@ Our conversation ends on a positive note, admitting to the intangible aspect of 
 
 * * *
 
-https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch/
+https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch

--- a/content/blog/2021/06/23/conscious-evolution-robert-cobbold.md
+++ b/content/blog/2021/06/23/conscious-evolution-robert-cobbold.md
@@ -54,6 +54,6 @@ _Sign up to our newsletter to keep up-to-date with all things Life Itself:_
 
 * * *
 
-https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch/
+https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality

--- a/content/blog/2021/07/02/richard-d-bartlett.md
+++ b/content/blog/2021/07/02/richard-d-bartlett.md
@@ -55,6 +55,6 @@ _Sign up to our newsletter to keep up-to-date with all things Life Itself:_
 
 * * *
 
-https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch/
+https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch
 
-https://lifeitself.org/2020/09/02/weve-published-our-ecosystem-snapshot-report/
+https://lifeitself.org/2020/09/02/weve-published-our-ecosystem-snapshot-report

--- a/content/blog/2021/07/13/ecosystem-mapping-conversation-4-with-alnoor-ladha.md
+++ b/content/blog/2021/07/13/ecosystem-mapping-conversation-4-with-alnoor-ladha.md
@@ -56,6 +56,6 @@ _Sign up to our newsletter to keep up-to-date with all things Life Itself:_
 
 * * *
 
-https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch/
+https://lifeitself.org/2021/10/12/state-of-sensemaking-directory-alpha-launch
 
-https://lifeitself.org/2020/09/02/weve-published-our-ecosystem-snapshot-report/
+https://lifeitself.org/2020/09/02/weve-published-our-ecosystem-snapshot-report

--- a/content/blog/2021/07/20/romy-kraemer-guerrilla-foundation.md
+++ b/content/blog/2021/07/20/romy-kraemer-guerrilla-foundation.md
@@ -54,6 +54,6 @@ _Sign up to our newsletter to keep up-to-date with all things Life Itself:_
 
 * * *
 
-https://lifeitself.org/2021/07/13/ecosystem-mapping-conversation-4-with-alnoor-ladha/
+https://lifeitself.org/2021/07/13/ecosystem-mapping-conversation-4-with-alnoor-ladha
 
-https://lifeitself.org/2021/06/23/conscious-evolution-robert-cobbold/
+https://lifeitself.org/2021/06/23/conscious-evolution-robert-cobbold

--- a/content/blog/2021/07/28/adam-brock-regenerate-change.md
+++ b/content/blog/2021/07/28/adam-brock-regenerate-change.md
@@ -44,6 +44,6 @@ _Sign up to our newsletter to keep up-to-date with all things Life Itself:_
 
 * * *
 
-https://lifeitself.org/2021/07/20/romy-kraemer-guerrilla-foundation/
+https://lifeitself.org/2021/07/20/romy-kraemer-guerrilla-foundation
 
-https://lifeitself.org/2021/07/14/what-is-conscious-coliving/
+https://lifeitself.org/2021/07/14/what-is-conscious-coliving

--- a/content/blog/2021/10/05/deliberately-developmental-spaces-a-key-to-addressing-the-metacrisis.md
+++ b/content/blog/2021/10/05/deliberately-developmental-spaces-a-key-to-addressing-the-metacrisis.md
@@ -156,6 +156,6 @@ Until then, we would like to leave a provocation for all those who view inner tr
 
 * * *
 
-https://lifeitself.org/2021/07/14/what-is-conscious-coliving/
+https://lifeitself.org/2021/07/14/what-is-conscious-coliving
 
-https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert/
+https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert

--- a/content/blog/2021/10/25/social-paradigm-shifts-a-pre-survey-of-the-literature.md
+++ b/content/blog/2021/10/25/social-paradigm-shifts-a-pre-survey-of-the-literature.md
@@ -79,6 +79,6 @@ Arditi, Jorge. ‘Geertz, Kuhn and the Idea of a Cultural Paradigm’. _The Brit
 
 * * *
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality
 
-https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality/
+https://lifeitself.org/2019/01/22/ken-wilber-integral-spirituality

--- a/content/blog/2021/12/22/conservative-planning-for-social-well-being.md
+++ b/content/blog/2021/12/22/conservative-planning-for-social-well-being.md
@@ -20,6 +20,6 @@ The obvious way of doing this is to emphasise policies that increase well-being 
 
 * * *
 
-https://lifeitself.org/2021/10/21/well-being-and-a-moderate-climate-movement/
+https://lifeitself.org/2021/10/21/well-being-and-a-moderate-climate-movement
 
-https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land/
+https://lifeitself.org/2018/01/24/the-ills-of-capitalism-the-possibilities-of-abundance-and-the-limits-of-land

--- a/content/blog/2022/05/21/crypto-can-these-financial-perpetual-motion-machines-work.md
+++ b/content/blog/2022/05/21/crypto-can-these-financial-perpetual-motion-machines-work.md
@@ -23,6 +23,6 @@ _Head over to our Making Sense of Crypto & Web3 site to read the full explainer.
 
 ## More from Life Itself Labs
 
-https://lifeitself.org/2022/04/08/mapping-metamodern-alternative-governance/
+https://lifeitself.org/2022/04/08/mapping-metamodern-alternative-governance
 
-https://lifeitself.org/2022/03/16/making-sense-of-crypto-and-web3-launch/
+https://lifeitself.org/2022/03/16/making-sense-of-crypto-and-web3-launch

--- a/content/blog/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science.md
+++ b/content/blog/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science.md
@@ -28,6 +28,6 @@ Head over to our residencies page to learn more about our residencies and to see
 
 * * *
 
-https://lifeitself.org/2022/04/25/reflections-on-the-making-eco-spirituality-accessible-residency/
+https://lifeitself.org/2022/04/25/reflections-on-the-making-eco-spirituality-accessible-residency
 
-https://lifeitself.org/2022/04/30/self-burning-confronts-us-with-radical-concern-if-we-let-it/
+https://lifeitself.org/2022/04/30/self-burning-confronts-us-with-radical-concern-if-we-let-it

--- a/content/blog/2022/06/09/exploring-social-transformation.md
+++ b/content/blog/2022/06/09/exploring-social-transformation.md
@@ -27,6 +27,6 @@ https://youtu.be/qh6bjLmtzzo
 
 https://youtu.be/O6DOI65x3hI
 
-https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science/
+https://lifeitself.org/2022/05/26/reflections-on-sympoiesis-6-insight-interbeing-and-science
 
-https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism/
+https://lifeitself.org/2022/03/11/mapping-metamodern-what-is-metamodernism

--- a/content/blog/2022/06/09/launch-announcement-life-itself-labs.md
+++ b/content/blog/2022/06/09/launch-announcement-life-itself-labs.md
@@ -29,6 +29,6 @@ Life Itself Labs offers a range of services, from research and workshop facilita
 
 https://youtu.be/qh6bjLmtzzo
 
-https://lifeitself.org/2022/06/09/exploring-social-transformation/
+https://lifeitself.org/2022/06/09/exploring-social-transformation
 
 https://untitled.community/tech-alone-cant-fix-governance/

--- a/content/blog/2022/06/15/collective-practice-and-the-life-itself-open-residency.md
+++ b/content/blog/2022/06/15/collective-practice-and-the-life-itself-open-residency.md
@@ -23,6 +23,6 @@ https://youtu.be/o1ROvFNrX0k
 
 ### _More from Life Itself_
 
-https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert/
+https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert
 
-https://lifeitself.org/2022/06/09/exploring-social-transformation/
+https://lifeitself.org/2022/06/09/exploring-social-transformation

--- a/content/blog/2022/06/20/collective-practice-with-valerie-duvauchelle.md
+++ b/content/blog/2022/06/20/collective-practice-with-valerie-duvauchelle.md
@@ -25,4 +25,4 @@ https://youtu.be/o1ROvFNrX0k
 
 ### _More from Life Itself_
 
-https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert/
+https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert

--- a/content/blog/2022/06/30/june-wrapped.md
+++ b/content/blog/2022/06/30/june-wrapped.md
@@ -94,7 +94,7 @@ I believe the answer is connection...."
 
 ## Latest Articles
 
-https://lifeitself.org/2022/06/17/history-humility-and-the-seeds-of-a-new-culture/
+https://lifeitself.org/2022/06/17/history-humility-and-the-seeds-of-a-new-culture
 
 ## Latest on YouTube
 

--- a/content/blog/2022/07/12/hannah-close-on-animism-kinship-and-the-social-change-ecosystem.md
+++ b/content/blog/2022/07/12/hannah-close-on-animism-kinship-and-the-social-change-ecosystem.md
@@ -18,6 +18,6 @@ Hannah is a curator for the transformative education platform [Advaya](https://a
 
 * * *
 
-https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality/
+https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality
 
-https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert/
+https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert

--- a/content/blog/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination.md
+++ b/content/blog/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination.md
@@ -24,6 +24,6 @@ Geoff Mulgan is Professor of Collective Intelligence, Public Policy and Social I
 
 ### _More from Life Itself_
 
-https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality/
+https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality
 
-https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert/
+https://lifeitself.org/2022/06/09/embodying-collective-transformation-with-karl-steyaert

--- a/content/blog/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews.md
+++ b/content/blog/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews.md
@@ -30,6 +30,6 @@ His new book, The Web of Meaning: Integrating Science and Traditional Wisdom to 
 
 ### _More from Life Itself_
 
-https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality/
+https://lifeitself.org/2022/06/21/brendan-graham-dempsey-on-the-meaning-crisis-metamodern-spirituality
 
-https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination/
+https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination

--- a/content/blog/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock.md
+++ b/content/blog/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock.md
@@ -32,6 +32,6 @@ Previously he has been the Mead Fellow in Economics at the University of Cambrid
 
 * * *
 
-https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews/
+https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews
 
-https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination/
+https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination

--- a/content/blog/2022/08/25/august-wrapped.md
+++ b/content/blog/2022/08/25/august-wrapped.md
@@ -30,7 +30,7 @@ Adults and children are both welcome for an afternoon of art and performance fro
 
 Learn more and book your ticket:
 
-https://lifeitself.org/27aout/
+https://lifeitself.org/27aout
 
 ## Crypto Policy Symposium 2022
 
@@ -67,7 +67,7 @@ These residencies are now fully booked, however, please do still get in touch if
 
 ### Jeremy Lent on Interconnection & Shifting Worldviews
 
-https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews/
+https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews
 
 <iframe src="https://anchor.fm/life-itself/embed/episodes/Jeremy-Lent-on-Interconnection--Shifting-Worldviews-e1ma31u/a-a7gpq18" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
 
@@ -75,7 +75,7 @@ In episode 7 of the Exploring Social Transformation series of the Life Itself Po
 
 ### The New School at Commonweal with Rufus Pollock
 
-https://lifeitself.org/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock/
+https://lifeitself.org/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock
 
 <iframe src="https://anchor.fm/life-itself/embed/episodes/Meet-the-MetaModerns-Emerging-Movement-with-Alternative-Approach-to-Social-Change-with-Rufus-Pollock-e1mhn48/a-a7gpq18" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
 

--- a/content/blog/2022/09/29/update-from-the-bergerac-hub-embodying-collective-transformation.md
+++ b/content/blog/2022/09/29/update-from-the-bergerac-hub-embodying-collective-transformation.md
@@ -80,6 +80,6 @@ Here are a few reflections from our Open Space Harvest Board, where members of t
 
 #### _More from Life Itself_
 
-https://lifeitself.org/blog/2022/09/15/vipassana-meditation-a-sensational-detachment/
+https://lifeitself.org/blog/2022/09/15/vipassana-meditation-a-sensational-detachment
 
-https://lifeitself.org/blog/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews/
+https://lifeitself.org/blog/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews

--- a/content/blog/2022/11/25/joseph-henrich-and-the-emergence-of-a-rigorous-culturology.md
+++ b/content/blog/2022/11/25/joseph-henrich-and-the-emergence-of-a-rigorous-culturology.md
@@ -212,8 +212,8 @@ Okay, great to be with you. Thanks.
 
 #### _More from Life Itself_
 
-https://lifeitself.org/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock/
+https://lifeitself.org/2022/08/16/the-new-school-at-commonweal-with-rufus-pollock
 
-https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews/
+https://lifeitself.org/2022/08/09/jeremy-lent-on-interconnection-shifting-worldviews
 
-https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination/
+https://lifeitself.org/2022/07/26/geoff-mulgan-on-reigniting-social-and-political-imagination

--- a/content/blog/2022/12/15/embodying-collective-transformation-reflections-and-highlights.md
+++ b/content/blog/2022/12/15/embodying-collective-transformation-reflections-and-highlights.md
@@ -50,6 +50,6 @@ We are grateful to everyone who contributed resources – time, money, energy, e
 
 #### _More from Life Itself_
 
-https://lifeitself.org/blog/2022/09/29/update-from-the-bergerac-hub-embodying-collective-transformation/
+https://lifeitself.org/blog/2022/09/29/update-from-the-bergerac-hub-embodying-collective-transformation
 
-https://lifeitself.org/blog/2022/11/11/embodying-collective-transformation-transform-what/
+https://lifeitself.org/blog/2022/11/11/embodying-collective-transformation-transform-what

--- a/content/blog/2022/12/15/life-itself-labs-year-end-review.md
+++ b/content/blog/2022/12/15/life-itself-labs-year-end-review.md
@@ -51,4 +51,4 @@ If you’re interested in deepening your understanding of some of the key issues
 
 #### _More from Life Itself Labs_
 
-https://lifeitself.org/2022/06/09/launch-announcement-life-itself-labs/
+https://lifeitself.org/2022/06/09/launch-announcement-life-itself-labs

--- a/content/institute/universal-basic-income.md
+++ b/content/institute/universal-basic-income.md
@@ -7,4 +7,4 @@ authors:
 
 This page collects our reflections and analysis of Universal Basic Income proposals.
 
-https://lifeitself.org/2019/09/08/andrew-yangs-universal-basic-income-proposal-ubi-does-it-add-up/
+https://lifeitself.org/2019/09/08/andrew-yangs-universal-basic-income-proposal-ubi-does-it-add-up

--- a/content/programs/open-residency.md
+++ b/content/programs/open-residency.md
@@ -90,4 +90,4 @@ Marc Santolini is a researcher at the Learning Planet Institute where he uses ne
 
 ### Learn more about our Sympoiesis residencies:
 
-https://lifeitself.org/sympoiesis/
+https://lifeitself.org/sympoiesis

--- a/public/_redirects
+++ b/public/_redirects
@@ -44,6 +44,7 @@
 /2015/:month/:date/:slug  /blog/2015/:month/:date/:slug
 /2016/:month/:date/:slug  /blog/2016/:month/:date/:slug
 /2017/:month/:date/:slug  /blog/2017/:month/:date/:slug
+/2017/:month/:date/:slug/  /blog/2017/:month/:date/:slug
 /2018/:month/:date/:slug  /blog/2018/:month/:date/:slug
 /2019/:month/:date/:slug  /blog/2019/:month/:date/:slug
 /2020/:month/:date/:slug  /blog/2020/:month/:date/:slug


### PR DESCRIPTION
Related to life-itself/next.lifeitself.org#23 

## Summary

Old in-markdown links with trailing slashes do not match the [redirect patterns](https://github.com/life-itself/community/blob/main/public/_redirects). This PR removes the trailing slash in all such links.